### PR TITLE
feat(agent): Allow GameInstance.using to activate multiple agents simultaneously using object destructuring

### DIFF
--- a/src/agents/activate-agent.ts
+++ b/src/agents/activate-agent.ts
@@ -1,0 +1,43 @@
+/**
+ * Contains the function implementation for activating a single agent
+ * within the current game context.
+ *
+ * Copyright (c) 2018 Joseph R Cowman
+ * Licensed under MIT License (see https://github.com/regal/regal)
+ */
+
+import GameInstance from "../game-instance";
+import { activeAgentProxy, Agent } from "./agent-model";
+
+/**
+ * Returns an activated agent within the current game context.
+ *
+ * Once an agent is activated, its data is managed by the `GameInstance`.
+ * An agent cannot be used until it is activated.
+ *
+ * @param game  The managing `GameInstance`.
+ * @param agent The agent to be activated (not modified).
+ */
+export const activateAgent = <T extends Agent>(
+    game: GameInstance,
+    agent: T
+): T => {
+    let id = agent.id;
+
+    if (id < 0) {
+        id = game.agents.reserveNewId();
+        agent.id = id;
+    }
+
+    const activeAgent = activeAgentProxy(id, game) as T;
+
+    const tempValues = (agent as any).tempValues;
+
+    if (tempValues !== undefined) {
+        for (const prop of Object.keys(tempValues)) {
+            activeAgent[prop] = tempValues[prop];
+        }
+    }
+
+    return activeAgent;
+};

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -14,3 +14,4 @@ export { Agent, activeAgentProxy } from "./agent-model";
 export { StaticAgentRegistry } from "./static-agent-registry";
 export { buildRevertFunction } from "./agent-revert";
 export { PropertyChange, PropertyOperation } from "./agent-properties";
+export { activateAgent } from "./activate-agent";

--- a/src/game-instance.ts
+++ b/src/game-instance.ts
@@ -12,12 +12,13 @@
  */
 
 import {
+    activateAgent,
     activeAgentProxy,
-    Agent,
     buildInstanceAgents,
     InstanceAgents,
     recycleInstanceAgents
 } from "./agents";
+import { isAgent } from "./agents/agent-model";
 import { GameOptions, InstanceOptions } from "./config";
 import { ContextManager } from "./context-manager";
 import { RegalError } from "./error";
@@ -92,24 +93,41 @@ export default class GameInstance {
         return newGame;
     }
 
-    public using<T extends Agent>(resource: T): T {
-        let id = resource.id;
-
-        if (id < 0) {
-            id = this.agents.reserveNewId();
-            resource.id = id;
+    /**
+     * Activates one or more agents in the current game context. All agents
+     * must be activated before they can be used. Activating an agent multiple
+     * times has no effect.
+     *
+     * @param resource Either a single agent or an object where every property
+     * is an agent to be activated.
+     * @returns Either an activated agent or an object where every property is
+     * an activated agent, depending on the structure of `resource`.
+     */
+    public using<T>(resource: T): T {
+        if (isAgent(resource)) {
+            return activateAgent(this, resource);
         }
 
-        const agent = activeAgentProxy(id, this) as T;
+        if (resource === undefined) {
+            throw new RegalError("Resource must be defined.");
+        }
 
-        const tempValues = (resource as any).tempValues;
+        const returnObj = {} as T;
 
-        if (tempValues !== undefined) {
-            for (const prop of Object.keys(tempValues)) {
-                agent[prop] = tempValues[prop];
+        for (const key in resource) {
+            if (resource.hasOwnProperty(key)) {
+                const agent = resource[key];
+
+                if (isAgent(agent)) {
+                    returnObj[key] = activateAgent(this, agent);
+                } else {
+                    throw new RegalError(
+                        `Invalid agent in resource at key <${key}>.`
+                    );
+                }
             }
         }
 
-        return agent;
+        return returnObj;
     }
 }

--- a/test/unit/game-instance.test.ts
+++ b/test/unit/game-instance.test.ts
@@ -6,6 +6,9 @@ import { MetadataManager } from "../../src/config";
 import { getDemoMetadata } from "../test-utils";
 import { Game } from "../../src/game-api";
 import { RegalError } from "../../src/error";
+import { Agent } from "http";
+
+// Note: Some tests for GameInstance.using are in agents.test.ts
 
 describe("GameInstance", function() {
     beforeEach(function() {
@@ -52,5 +55,27 @@ describe("GameInstance", function() {
             RegalError,
             "Cannot construct a GameInstance outside of a game cycle."
         );
+    });
+
+    it("Throw an error if GameInstance.using is called with undefined", function() {
+        expect(() => new GameInstance().using(undefined)).to.throw(
+            RegalError,
+            "Resource must be defined"
+        );
+    });
+
+    it("Throw an error if GameInstance.using is called with an illegal object", function() {
+        expect(() => new GameInstance().using({ foo: "bar" })).to.throw(
+            RegalError,
+            "Invalid agent in resource at key <foo>."
+        );
+    });
+
+    it("GameInstance.using only references properties on the resource object itself", function() {
+        class WeirdResource {}
+        (WeirdResource as any).prototype.foo = "bar";
+
+        const game = new GameInstance();
+        expect("foo" in game.using(new WeirdResource())).to.be.false;
     });
 });


### PR DESCRIPTION
## Changes
* `GameInstance.using` can now take an object with multiple agents as properties, and will return an object of the same structure with every corresponding key now a registered version of that agent.
* Add documentation
* Unit tests

## Related Issues
* Resolves #44 