### PR TITLE
feat(agent): Adds trackAgentChanges game option to make full event sourcing optional

### DIFF
--- a/src/agents/agent-manager.ts
+++ b/src/agents/agent-manager.ts
@@ -6,7 +6,12 @@
  */
 
 import GameInstance from "../game-instance";
-import { PropertyChange, PropertyOperation } from "./agent-properties";
+import {
+    pcForAgentManager,
+    pcForEventRecord,
+    PropertyChange,
+    PropertyOperation
+} from "./agent-properties";
 import { StaticAgentRegistry } from "./static-agent-registry";
 
 /**
@@ -141,15 +146,20 @@ class AgentManagerImpl implements AgentManager {
         }
 
         const event = this.game.events.current;
-        event.trackChange(this.id, property, opType, initValue, value);
 
-        history.unshift({
+        const propChange: PropertyChange = {
+            agentId: this.id,
             eventId: event.id,
             eventName: event.name,
             final: value,
             init: initValue,
-            op: opType
-        });
+            op: opType,
+            property: property.toString()
+        };
+
+        event.trackChange(pcForEventRecord(propChange));
+
+        history.unshift(pcForAgentManager(propChange));
     }
 
     public deleteProperty(property: PropertyKey): void {
@@ -176,20 +186,19 @@ class AgentManagerImpl implements AgentManager {
         }
 
         const event = this.game.events.current;
-        event.trackChange(
-            this.id,
-            property,
-            PropertyOperation.DELETED,
-            initValue,
-            undefined
-        );
 
-        history.unshift({
+        const propChange: PropertyChange = {
+            agentId: this.id,
             eventId: event.id,
             eventName: event.name,
             final: undefined,
             init: initValue,
-            op: PropertyOperation.DELETED
-        });
+            op: PropertyOperation.DELETED,
+            property: property.toString()
+        };
+
+        event.trackChange(pcForEventRecord(propChange));
+
+        history.unshift(pcForAgentManager(propChange));
     }
 }

--- a/src/agents/agent-manager.ts
+++ b/src/agents/agent-manager.ts
@@ -6,7 +6,7 @@
  */
 
 import { RegalError } from "../error";
-import { DEFAULT_EVENT_ID, EventRecord } from "../events/event-record";
+import { DEFAULT_EVENT_ID, EventRecord } from "../events";
 import GameInstance from "../game-instance";
 import {
     pcForAgentManager,

--- a/src/agents/agent-model.ts
+++ b/src/agents/agent-model.ts
@@ -45,7 +45,11 @@ export const inactiveAgentProxy = (agent: Agent): Agent =>
                 return this.tempValues;
             }
 
-            if (property !== "id" && !ContextManager.isContextStatic()) {
+            if (
+                property !== "id" &&
+                property !== "refId" &&
+                !ContextManager.isContextStatic()
+            ) {
                 throw new RegalError(
                     "The properties of an inactive agent cannot be accessed within a game cycle."
                 );

--- a/src/agents/agent-properties.ts
+++ b/src/agents/agent-properties.ts
@@ -42,3 +42,21 @@ export interface PropertyChange {
     /** The property's name (optional). */
     property?: string;
 }
+
+/** Convert the given `PropertyChange` into the appropriate view for an `AgentManager`. */
+export const pcForAgentManager = (pc: PropertyChange): PropertyChange => ({
+    eventId: pc.eventId,
+    eventName: pc.eventName,
+    final: pc.final,
+    init: pc.init,
+    op: pc.op
+});
+
+/** Convert the given PropertyChange into the appropriate view for an `EventRecord`. */
+export const pcForEventRecord = (pc: PropertyChange): PropertyChange => ({
+    agentId: pc.agentId,
+    final: pc.final,
+    init: pc.init,
+    op: pc.op,
+    property: pc.property
+});

--- a/src/agents/agent-properties.ts
+++ b/src/agents/agent-properties.ts
@@ -5,6 +5,9 @@
  * Licensed under MIT License (see https://github.com/regal/regal)
  */
 
+// tslint:disable-next-line
+true; // This does nothing; it's only so the jsdocs won't conflict
+
 /** Type of modification done to an agent's property. */
 export enum PropertyOperation {
     /** The property was added to the agent. */

--- a/src/config/game-options.ts
+++ b/src/config/game-options.ts
@@ -29,6 +29,16 @@ export interface GameOptions {
 
     /** Whether output of type `MINOR` should be returned to the client. Defaults to true. */
     showMinor: boolean;
+
+    /**
+     * Whether all changes to agent properties are tracked and returned to the client. Defaults to false.
+     *
+     * If `false`, only the values of each property at the beginning and end of each game cycle will be
+     * recorded.
+     *
+     * If `true`, all property changes will be recorded.
+     */
+    trackAgentChanges: boolean;
 }
 
 /**
@@ -39,7 +49,8 @@ export interface GameOptions {
 export const DEFAULT_GAME_OPTIONS: GameOptions = {
     allowOverrides: true,
     debug: false,
-    showMinor: true
+    showMinor: true,
+    trackAgentChanges: false
 };
 
 /** The names of every game option. */
@@ -102,4 +113,5 @@ export const validateOptions = (options: Partial<GameOptions>): void => {
     }
 
     checkTypeIfDefined("showMinor", "boolean");
+    checkTypeIfDefined("trackAgentChanges", "boolean");
 };

--- a/src/config/instance-options.ts
+++ b/src/config/instance-options.ts
@@ -79,14 +79,10 @@ export const ensureOverridesAllowed = (
  * Read-only container that provides an API to view the game instance's current game options.
  */
 export class InstanceOptions implements GameOptions {
-    /** Game options that can be overridden by a Regal client. */
     public allowOverrides: string[] | boolean;
-
-    /** Whether output of type `DEBUG` should be returned to the client. */
     public debug: boolean;
-
-    /** Whether output of type `MINOR` should be returned to the client. */
     public showMinor: boolean;
+    public trackAgentChanges: boolean;
 
     /** Options that have had their static values overridden by the client. */
     public overrides: Readonly<Partial<GameOptions>>;

--- a/src/events/event-record.ts
+++ b/src/events/event-record.ts
@@ -71,29 +71,12 @@ export class EventRecord {
     /**
      * Adds a record of a single change to a registered agent's property to the
      * `EventRecord`'s `changes` property.
-     *
-     * @param agentId The registered agent's ID.
-     * @param property The property being modified.
-     * @param op The type of modification.
-     * @param init The initial value of the property.
-     * @param final The final value of the property.
      */
-    public trackChange<T>(
-        agentId: number,
-        property: PropertyKey,
-        op: PropertyOperation,
-        init?: T,
-        final?: T
-    ): void {
+    public trackChange(propChange: PropertyChange): void {
         if (this.changes === undefined) {
             this.changes = [];
         }
-        this.changes.push({
-            agentId,
-            final,
-            init,
-            op,
-            property: property.toString()
-        });
+
+        this.changes.push(propChange);
     }
 }

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -16,5 +16,9 @@ export {
     isEventQueue,
     isTrackedEvent
 } from "./event-model";
-export { EventRecord } from "./event-record";
+export {
+    EventRecord,
+    DEFAULT_EVENT_ID,
+    DEFAULT_EVENT_NAME
+} from "./event-record";
 export { default as InstanceEvents } from "./instance-events";

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,3 @@
 --compilers ts-node/register
 --require source-map-support/register
---full-trace
 test/unit/**/*.test.ts

--- a/test/unit/agents.test.ts
+++ b/test/unit/agents.test.ts
@@ -758,7 +758,7 @@ describe("Agents", function() {
         it("InstanceAgents.recycle creates all new agents that have only the last values of each of the original agent' properties", function() {
             Game.init();
 
-            const myGame = new GameInstance();
+            const myGame = new GameInstance({ trackAgentChanges: true });
 
             on("INIT", game => {
                 game.state.dummy = new Dummy("D1", 10);
@@ -814,6 +814,125 @@ describe("Agents", function() {
                             init: undefined,
                             final: "D1",
                             op: PropertyOperation.ADDED
+                        }
+                    ],
+                    health: [
+                        {
+                            eventId: 1,
+                            eventName: "INIT",
+                            init: undefined,
+                            final: 10,
+                            op: PropertyOperation.ADDED
+                        }
+                    ]
+                }
+            });
+
+            const myGame2 = myGame.recycle();
+
+            expect(myGame2.agents).to.deep.equal({
+                game: myGame2,
+                0: {
+                    id: 0,
+                    game: myGame2,
+                    dummy: [
+                        {
+                            eventId: 0,
+                            eventName: "DEFAULT",
+                            init: undefined,
+                            final: {
+                                refId: 1
+                            },
+                            op: PropertyOperation.ADDED
+                        }
+                    ],
+                    foo: [
+                        {
+                            eventId: 0,
+                            eventName: "DEFAULT",
+                            init: undefined,
+                            final: true,
+                            op: PropertyOperation.ADDED
+                        }
+                    ]
+                },
+                1: {
+                    id: 1,
+                    game: myGame2,
+                    name: [
+                        {
+                            eventId: 0,
+                            eventName: "DEFAULT",
+                            init: undefined,
+                            final: "Jimmy",
+                            op: PropertyOperation.ADDED
+                        }
+                    ],
+                    health: [
+                        {
+                            eventId: 0,
+                            eventName: "DEFAULT",
+                            init: undefined,
+                            final: 10,
+                            op: PropertyOperation.ADDED
+                        }
+                    ]
+                }
+            });
+        });
+
+        it("InstanceAgents.recycle creates all new agents that have only the last values of each of the original agent' properties (without tracking agent properties)", function() {
+            Game.init();
+
+            const myGame = new GameInstance();
+
+            on("INIT", game => {
+                game.state.dummy = new Dummy("D1", 10);
+
+                return on("MOD", game => {
+                    game.state.dummy.name = "Jimmy";
+                    game.state.foo = true;
+                    return noop;
+                });
+            })(myGame);
+
+            // Verify initial condition
+            expect(myGame.agents).to.deep.equal({
+                game: myGame,
+                0: {
+                    id: 0,
+                    game: myGame,
+                    dummy: [
+                        {
+                            eventId: 1,
+                            eventName: "INIT",
+                            init: undefined,
+                            final: {
+                                refId: 1
+                            },
+                            op: PropertyOperation.ADDED
+                        }
+                    ],
+                    foo: [
+                        {
+                            eventId: 2,
+                            eventName: "MOD",
+                            init: undefined,
+                            final: true,
+                            op: PropertyOperation.ADDED
+                        }
+                    ]
+                },
+                1: {
+                    id: 1,
+                    game: myGame,
+                    name: [
+                        {
+                            eventId: 2,
+                            eventName: "MOD",
+                            init: "D1",
+                            final: "Jimmy",
+                            op: PropertyOperation.MODIFIED
                         }
                     ],
                     health: [
@@ -1466,7 +1585,7 @@ describe("Agents", function() {
 
             Game.init();
 
-            const myGame = new GameInstance();
+            const myGame = new GameInstance({ trackAgentChanges: true });
             init(myGame);
 
             for (let x = 0; x < 10; x++) {
@@ -1504,7 +1623,7 @@ describe("Agents", function() {
 
             Game.init();
 
-            const myGame = new GameInstance();
+            const myGame = new GameInstance({ trackAgentChanges: true });
             init(myGame);
 
             for (let x = 0; x < 10; x++) {

--- a/test/unit/api-hooks.test.ts
+++ b/test/unit/api-hooks.test.ts
@@ -9,7 +9,7 @@ import {
 } from "../../src/api-hooks";
 import GameInstance from "../../src/game-instance";
 import { noop, on } from "../../src/events";
-import { log, getDemoMetadata } from "../test-utils";
+import { metadataWithOptions } from "../test-utils";
 import { PropertyOperation } from "../../src/agents";
 import { RegalError } from "../../src/error";
 import { MetadataManager } from "../../src/config";
@@ -18,7 +18,9 @@ import { Game } from "../../src/game-api";
 describe("API Hooks", function() {
     beforeEach(function() {
         Game.reset();
-        MetadataManager.setMetadata(getDemoMetadata());
+        MetadataManager.setMetadata(
+            metadataWithOptions({ trackAgentChanges: true })
+        );
         Game.init();
     });
 

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -10,8 +10,17 @@ import {
     ensureOverridesAllowed
 } from "../../src/config";
 import { OutputLineType } from "../../src/output";
-import { getDemoMetadata, metadataWithOptions } from "../test-utils";
+import { getDemoMetadata, metadataWithOptions, log } from "../test-utils";
 import { Game } from "../../src/game-api";
+import { on, noop } from "../../src/events";
+import { onStartCommand, onPlayerCommand } from "../../src/api-hooks";
+import { Agent, PropertyOperation } from "../../src/agents";
+
+class Dummy extends Agent {
+    constructor(public name: string, public health: number) {
+        super();
+    }
+}
 
 describe("Config", function() {
     beforeEach(function() {
@@ -127,9 +136,19 @@ describe("Config", function() {
                     "RegalError: The option <showMinor> is of type <number>, must be of type <boolean>."
                 );
             });
+
+            it("GameOptions.trackAgentChanges VALID", function() {
+                const myGame = new GameInstance({ trackAgentChanges: true });
+                expect(myGame.options.overrides).to.deep.equal({
+                    trackAgentChanges: true
+                });
+                expect(myGame.options.trackAgentChanges).to.be.true;
+            });
         });
 
         describe("Option Behavior", function() {
+            // debug
+
             it("DEBUG output is not printed when GameOptions.debug is set to false", function() {
                 const myGame = new GameInstance({ debug: false });
                 myGame.output.writeDebug("Hello, world!");
@@ -150,6 +169,8 @@ describe("Config", function() {
                 ]);
             });
 
+            // showMinor
+
             it("MINOR output is not printed when GameOptions.showMinor is set to false", function() {
                 const myGame = new GameInstance({ showMinor: false });
                 myGame.output.writeMinor("Hello, world!");
@@ -168,6 +189,617 @@ describe("Config", function() {
                         data: "Hello, world!"
                     }
                 ]);
+            });
+
+            // trackAgentChanges
+
+            function prepAgentTest() {
+                const introduce = on("INTRODUCE", game => {
+                    game.output.write(
+                        `My name is ${game.state.currentDummy.name}. ${game
+                            .state.dummyCount - 1} have come before me.`
+                    );
+                    game.state.currentDummy.health += 5;
+                    return noop;
+                });
+
+                const addDummy = (name: string) =>
+                    on("ADD", game => {
+                        const dummy = game.using(new Dummy(name, 10));
+                        dummy.name += " the Great";
+
+                        game.state.currentDummy = dummy;
+                        game.state.dummyCount++;
+
+                        return introduce;
+                    });
+
+                const init = on("INIT", game => {
+                    game.state.dummyCount = 0;
+                    return noop;
+                });
+
+                onStartCommand(init);
+                onPlayerCommand(addDummy);
+            }
+
+            it("Full agent property history is shown when GameOptions.trackAgentChanges is set to true", function() {
+                prepAgentTest();
+
+                let response = Game.postStartCommand({
+                    trackAgentChanges: true
+                });
+
+                expect(response.instance.agents).to.deep.equal({
+                    game: response.instance,
+                    "0": {
+                        id: 0,
+                        game: response.instance,
+                        dummyCount: [
+                            {
+                                eventId: 2,
+                                eventName: "INIT",
+                                final: 0,
+                                init: undefined,
+                                op: PropertyOperation.ADDED
+                            }
+                        ]
+                    }
+                });
+                expect(response.instance.events.history).to.deep.equal([
+                    {
+                        id: 2,
+                        name: "INIT",
+                        causedBy: 1,
+                        changes: [
+                            {
+                                agentId: 0,
+                                final: 0,
+                                init: undefined,
+                                op: PropertyOperation.ADDED,
+                                property: "dummyCount"
+                            }
+                        ]
+                    },
+                    {
+                        id: 1,
+                        name: "START",
+                        caused: [2]
+                    }
+                ]);
+
+                response = Game.postPlayerCommand(response.instance, "Lars");
+
+                expect(response.instance.agents).to.deep.equal({
+                    game: response.instance,
+                    "0": {
+                        id: 0,
+                        game: response.instance,
+                        dummyCount: [
+                            {
+                                eventId: 4,
+                                eventName: "ADD",
+                                final: 1,
+                                init: 0,
+                                op: PropertyOperation.MODIFIED
+                            },
+                            {
+                                eventId: 0,
+                                eventName: "DEFAULT",
+                                final: 0,
+                                init: undefined,
+                                op: PropertyOperation.ADDED
+                            }
+                        ],
+                        currentDummy: [
+                            {
+                                eventId: 4,
+                                eventName: "ADD",
+                                final: { refId: 1 },
+                                init: undefined,
+                                op: PropertyOperation.ADDED
+                            }
+                        ]
+                    },
+                    "1": {
+                        id: 1,
+                        game: response.instance,
+                        name: [
+                            {
+                                eventId: 4,
+                                eventName: "ADD",
+                                final: "Lars the Great",
+                                init: "Lars",
+                                op: PropertyOperation.MODIFIED
+                            },
+                            {
+                                eventId: 4,
+                                eventName: "ADD",
+                                final: "Lars",
+                                init: undefined,
+                                op: PropertyOperation.ADDED
+                            }
+                        ],
+                        health: [
+                            {
+                                eventId: 5,
+                                eventName: "INTRODUCE",
+                                final: 15,
+                                init: 10,
+                                op: PropertyOperation.MODIFIED
+                            },
+                            {
+                                eventId: 4,
+                                eventName: "ADD",
+                                final: 10,
+                                init: undefined,
+                                op: PropertyOperation.ADDED
+                            }
+                        ]
+                    }
+                });
+                expect(response.instance.events.history).to.deep.equal([
+                    {
+                        id: 5,
+                        name: "INTRODUCE",
+                        causedBy: 4,
+                        output: [1],
+                        changes: [
+                            {
+                                agentId: 1,
+                                final: 15,
+                                init: 10,
+                                op: PropertyOperation.MODIFIED,
+                                property: "health"
+                            }
+                        ]
+                    },
+                    {
+                        id: 4,
+                        name: "ADD",
+                        causedBy: 3,
+                        caused: [5],
+                        changes: [
+                            {
+                                agentId: 1,
+                                final: "Lars",
+                                init: undefined,
+                                op: PropertyOperation.ADDED,
+                                property: "name"
+                            },
+                            {
+                                agentId: 1,
+                                final: 10,
+                                init: undefined,
+                                op: PropertyOperation.ADDED,
+                                property: "health"
+                            },
+                            {
+                                agentId: 1,
+                                final: "Lars the Great",
+                                init: "Lars",
+                                op: PropertyOperation.MODIFIED,
+                                property: "name"
+                            },
+                            {
+                                agentId: 0,
+                                final: { refId: 1 },
+                                init: undefined,
+                                op: PropertyOperation.ADDED,
+                                property: "currentDummy"
+                            },
+                            {
+                                agentId: 0,
+                                final: 1,
+                                init: 0,
+                                op: PropertyOperation.MODIFIED,
+                                property: "dummyCount"
+                            }
+                        ]
+                    },
+                    {
+                        id: 3,
+                        name: "INPUT",
+                        caused: [4]
+                    }
+                ]);
+
+                response = Game.postPlayerCommand(response.instance, "Jeffrey");
+
+                expect(response.instance.agents).to.deep.equal({
+                    game: response.instance,
+                    "0": {
+                        id: 0,
+                        game: response.instance,
+                        dummyCount: [
+                            {
+                                eventId: 7,
+                                eventName: "ADD",
+                                final: 2,
+                                init: 1,
+                                op: PropertyOperation.MODIFIED
+                            },
+                            {
+                                eventId: 0,
+                                eventName: "DEFAULT",
+                                final: 1,
+                                init: undefined,
+                                op: PropertyOperation.ADDED
+                            }
+                        ],
+                        currentDummy: [
+                            {
+                                eventId: 7,
+                                eventName: "ADD",
+                                final: { refId: 2 },
+                                init: { refId: 1 },
+                                op: PropertyOperation.MODIFIED
+                            },
+                            {
+                                eventId: 0,
+                                eventName: "DEFAULT",
+                                final: { refId: 1 },
+                                init: undefined,
+                                op: PropertyOperation.ADDED
+                            }
+                        ]
+                    },
+                    "1": {
+                        id: 1,
+                        game: response.instance,
+                        name: [
+                            {
+                                eventId: 0,
+                                eventName: "DEFAULT",
+                                final: "Lars the Great",
+                                init: undefined,
+                                op: PropertyOperation.ADDED
+                            }
+                        ],
+                        health: [
+                            {
+                                eventId: 0,
+                                eventName: "DEFAULT",
+                                final: 15,
+                                init: undefined,
+                                op: PropertyOperation.ADDED
+                            }
+                        ]
+                    },
+                    "2": {
+                        id: 2,
+                        game: response.instance,
+                        name: [
+                            {
+                                eventId: 7,
+                                eventName: "ADD",
+                                final: "Jeffrey the Great",
+                                init: "Jeffrey",
+                                op: PropertyOperation.MODIFIED
+                            },
+                            {
+                                eventId: 7,
+                                eventName: "ADD",
+                                final: "Jeffrey",
+                                init: undefined,
+                                op: PropertyOperation.ADDED
+                            }
+                        ],
+                        health: [
+                            {
+                                eventId: 8,
+                                eventName: "INTRODUCE",
+                                final: 15,
+                                init: 10,
+                                op: PropertyOperation.MODIFIED
+                            },
+                            {
+                                eventId: 7,
+                                eventName: "ADD",
+                                final: 10,
+                                init: undefined,
+                                op: PropertyOperation.ADDED
+                            }
+                        ]
+                    }
+                });
+                expect(response.instance.events.history).to.deep.equal([
+                    {
+                        id: 8,
+                        name: "INTRODUCE",
+                        causedBy: 7,
+                        output: [2],
+                        changes: [
+                            {
+                                agentId: 2,
+                                final: 15,
+                                init: 10,
+                                op: PropertyOperation.MODIFIED,
+                                property: "health"
+                            }
+                        ]
+                    },
+                    {
+                        id: 7,
+                        name: "ADD",
+                        causedBy: 6,
+                        caused: [8],
+                        changes: [
+                            {
+                                agentId: 2,
+                                final: "Jeffrey",
+                                init: undefined,
+                                op: PropertyOperation.ADDED,
+                                property: "name"
+                            },
+                            {
+                                agentId: 2,
+                                final: 10,
+                                init: undefined,
+                                op: PropertyOperation.ADDED,
+                                property: "health"
+                            },
+                            {
+                                agentId: 2,
+                                final: "Jeffrey the Great",
+                                init: "Jeffrey",
+                                op: PropertyOperation.MODIFIED,
+                                property: "name"
+                            },
+                            {
+                                agentId: 0,
+                                final: { refId: 2 },
+                                init: { refId: 1 },
+                                op: PropertyOperation.MODIFIED,
+                                property: "currentDummy"
+                            },
+                            {
+                                agentId: 0,
+                                final: 2,
+                                init: 1,
+                                op: PropertyOperation.MODIFIED,
+                                property: "dummyCount"
+                            }
+                        ]
+                    },
+                    {
+                        id: 6,
+                        name: "INPUT",
+                        caused: [7]
+                    }
+                ]);
+            });
+
+            it("Reduced agent property history is shown when GameOptions.trackAgentChanges is set to false", function() {
+                prepAgentTest();
+
+                let response = Game.postStartCommand({
+                    trackAgentChanges: false
+                });
+
+                expect(response.instance.agents).to.deep.equal({
+                    game: response.instance,
+                    "0": {
+                        id: 0,
+                        game: response.instance,
+                        dummyCount: [
+                            {
+                                eventId: 2,
+                                eventName: "INIT",
+                                final: 0,
+                                init: undefined,
+                                op: PropertyOperation.ADDED
+                            }
+                        ]
+                    }
+                });
+                expect(response.instance.events.history).to.deep.equal([
+                    {
+                        id: 2,
+                        name: "INIT",
+                        causedBy: 1
+                    },
+                    {
+                        id: 1,
+                        name: "START",
+                        caused: [2]
+                    }
+                ]);
+
+                response = Game.postPlayerCommand(response.instance, "Lars");
+
+                expect(response.instance.agents).to.deep.equal({
+                    game: response.instance,
+                    "0": {
+                        id: 0,
+                        game: response.instance,
+                        dummyCount: [
+                            {
+                                eventId: 4,
+                                eventName: "ADD",
+                                final: 1,
+                                init: 0,
+                                op: PropertyOperation.MODIFIED
+                            },
+                            {
+                                eventId: 0,
+                                eventName: "DEFAULT",
+                                final: 0,
+                                init: undefined,
+                                op: PropertyOperation.ADDED
+                            }
+                        ],
+                        currentDummy: [
+                            {
+                                eventId: 4,
+                                eventName: "ADD",
+                                final: { refId: 1 },
+                                init: undefined,
+                                op: PropertyOperation.ADDED
+                            }
+                        ]
+                    },
+                    "1": {
+                        id: 1,
+                        game: response.instance,
+                        name: [
+                            {
+                                eventId: 4,
+                                eventName: "ADD",
+                                final: "Lars the Great",
+                                init: "Lars",
+                                op: PropertyOperation.MODIFIED
+                            }
+                        ],
+                        health: [
+                            {
+                                eventId: 5,
+                                eventName: "INTRODUCE",
+                                final: 15,
+                                init: 10,
+                                op: PropertyOperation.MODIFIED
+                            }
+                        ]
+                    }
+                });
+                expect(response.instance.events.history).to.deep.equal([
+                    {
+                        id: 5,
+                        name: "INTRODUCE",
+                        causedBy: 4,
+                        output: [1]
+                    },
+                    {
+                        id: 4,
+                        name: "ADD",
+                        causedBy: 3,
+                        caused: [5]
+                    },
+                    {
+                        id: 3,
+                        name: "INPUT",
+                        caused: [4]
+                    }
+                ]);
+
+                response = Game.postPlayerCommand(response.instance, "Jeffrey");
+
+                expect(response.instance.agents).to.deep.equal({
+                    game: response.instance,
+                    "0": {
+                        id: 0,
+                        game: response.instance,
+                        dummyCount: [
+                            {
+                                eventId: 7,
+                                eventName: "ADD",
+                                final: 2,
+                                init: 1,
+                                op: PropertyOperation.MODIFIED
+                            },
+                            {
+                                eventId: 0,
+                                eventName: "DEFAULT",
+                                final: 1,
+                                init: undefined,
+                                op: PropertyOperation.ADDED
+                            }
+                        ],
+                        currentDummy: [
+                            {
+                                eventId: 7,
+                                eventName: "ADD",
+                                final: { refId: 2 },
+                                init: { refId: 1 },
+                                op: PropertyOperation.MODIFIED
+                            },
+                            {
+                                eventId: 0,
+                                eventName: "DEFAULT",
+                                final: { refId: 1 },
+                                init: undefined,
+                                op: PropertyOperation.ADDED
+                            }
+                        ]
+                    },
+                    "1": {
+                        id: 1,
+                        game: response.instance,
+                        name: [
+                            {
+                                eventId: 0,
+                                eventName: "DEFAULT",
+                                final: "Lars the Great",
+                                init: undefined,
+                                op: PropertyOperation.ADDED
+                            }
+                        ],
+                        health: [
+                            {
+                                eventId: 0,
+                                eventName: "DEFAULT",
+                                final: 15,
+                                init: undefined,
+                                op: PropertyOperation.ADDED
+                            }
+                        ]
+                    },
+                    "2": {
+                        id: 2,
+                        game: response.instance,
+                        name: [
+                            {
+                                eventId: 7,
+                                eventName: "ADD",
+                                final: "Jeffrey the Great",
+                                init: "Jeffrey",
+                                op: PropertyOperation.MODIFIED
+                            }
+                        ],
+                        health: [
+                            {
+                                eventId: 8,
+                                eventName: "INTRODUCE",
+                                final: 15,
+                                init: 10,
+                                op: PropertyOperation.MODIFIED
+                            }
+                        ]
+                    }
+                });
+                expect(response.instance.events.history).to.deep.equal([
+                    {
+                        id: 8,
+                        name: "INTRODUCE",
+                        causedBy: 7,
+                        output: [2]
+                    },
+                    {
+                        id: 7,
+                        name: "ADD",
+                        causedBy: 6,
+                        caused: [8]
+                    },
+                    {
+                        id: 6,
+                        name: "INPUT",
+                        caused: [7]
+                    }
+                ]);
+            });
+
+            it("Throw an error if a property history is longer than 1 when trackAgentChanges is disabled", function() {
+                const myGame = new GameInstance({ trackAgentChanges: false });
+                const d = myGame.using(new Dummy("D1", 10));
+                myGame.agents
+                    .getAgentManager(1)
+                    .getPropertyHistory("name")
+                    .unshift({} as any);
+
+                expect(() => (d.name = "Foo")).to.throw(
+                    RegalError,
+                    "Property history length cannot be greater than one when trackAgentChanges is disabled"
+                );
             });
         });
     });

--- a/test/unit/events.test.ts
+++ b/test/unit/events.test.ts
@@ -684,7 +684,7 @@ describe("Events", function() {
 
             Game.init();
 
-            const myGame = new GameInstance();
+            const myGame = new GameInstance({ trackAgentChanges: true });
             const dummy = myGame.using(new Dummy("Lars", 10));
 
             heal(dummy, 15)(myGame);
@@ -756,7 +756,7 @@ describe("Events", function() {
 
             Game.init();
 
-            const myGame = new GameInstance();
+            const myGame = new GameInstance({ trackAgentChanges: true });
             start(myGame);
 
             expect(myGame.events.history).to.deep.equal([


### PR DESCRIPTION
## Changes
* Added `trackAgentChanges` option that skips tracking all non-vital (for reverting) property changes from `AgentManager`s and doesn't record changes in `EventRecord`s (defaults to `true`).
* Various refactors to make tracking more streamlined.
* Unit tests

## Related Issues
* Resolves #46 