### PR TITLE
fix(agent): All inaccessible data is scrubbed from InstanceAgents before each player command

### DIFF
--- a/src/agents/agent-scrub.ts
+++ b/src/agents/agent-scrub.ts
@@ -1,9 +1,27 @@
+/**
+ * Contains `scrubAgents` function, which deletes all agents in an
+ * `InstanceAgents` that are not accessible from the instance's state.
+ *
+ * Copyright (c) 2018 Joseph R Cowman
+ * Licensed under MIT License (see https://github.com/regal/regal)
+ */
+
 import { isAgent } from "./agent-model";
 import { InstanceAgents, propertyIsAgentId } from "./instance-agents";
 
+/**
+ * Traverses all agents that are accessible from the `GameInstance`'s
+ * state via breadth-first search. All remaining agents (the ones with
+ * no references to them) are deleted from the `InstanceAgents`.
+ *
+ * If run at the improper time, this will break event sourcing and/or
+ * instance reverting. Make sure to use this correctly.
+ *
+ * @param agents The `InstanceAgents` to be scrubbed.
+ */
 export const scrubAgents = (agents: InstanceAgents): void => {
     const seen = new Set<number>();
-    const q = [0];
+    const q = [0]; // Start at the state, which always has an id of zero
 
     while (q.length > 0) {
         const id = q.shift();

--- a/src/agents/agent-scrub.ts
+++ b/src/agents/agent-scrub.ts
@@ -1,0 +1,27 @@
+import { isAgent } from "./agent-model";
+import { InstanceAgents, propertyIsAgentId } from "./instance-agents";
+
+export const scrubAgents = (agents: InstanceAgents): void => {
+    const seen = new Set<number>();
+    const q = [0];
+
+    while (q.length > 0) {
+        const id = q.shift();
+        seen.add(id);
+
+        for (const prop of agents.getAgentPropertyKeys(id)) {
+            const val = agents.getAgentProperty(id, prop);
+            if (isAgent(val) && !seen.has(val.id)) {
+                q.push(val.id);
+            }
+        }
+    }
+
+    const waste = Object.keys(agents)
+        .filter(propertyIsAgentId)
+        .filter(id => !seen.has(Number(id)));
+
+    for (const id of waste) {
+        delete agents[id];
+    }
+};

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -15,3 +15,4 @@ export { StaticAgentRegistry } from "./static-agent-registry";
 export { buildRevertFunction } from "./agent-revert";
 export { PropertyChange, PropertyOperation } from "./agent-properties";
 export { activateAgent } from "./activate-agent";
+export { scrubAgents } from "./agent-scrub";

--- a/src/agents/instance-agents.ts
+++ b/src/agents/instance-agents.ts
@@ -127,6 +127,7 @@ export const recycleInstanceAgents = (
     newInstance: GameInstance
 ): InstanceAgents => {
     const newAgents = new InstanceAgentsImpl(newInstance);
+    newAgents._nextId = (oldAgents as InstanceAgentsImpl)._nextId;
 
     for (const formerAgent of oldAgents.agentManagers()) {
         const id = formerAgent.id;
@@ -167,8 +168,11 @@ export const propertyIsAgentId = (property: PropertyKey) => {
 
 /** Implementation of `InstanceAgents`. */
 class InstanceAgentsImpl implements InstanceAgents {
+    public _nextId: number;
+
     constructor(public game: GameInstance) {
         this.createAgentManager(0);
+        this._nextId = StaticAgentRegistry.getNextAvailableId();
     }
 
     public agentManagers(): AgentManager[] {
@@ -178,12 +182,8 @@ class InstanceAgentsImpl implements InstanceAgents {
     }
 
     public reserveNewId(): number {
-        const agentKeys = Object.keys(this).filter(propertyIsAgentId);
-        let id = StaticAgentRegistry.getNextAvailableId();
-
-        while (agentKeys.includes(id.toString())) {
-            id++;
-        }
+        const id = this._nextId;
+        this._nextId++;
 
         this.createAgentManager(id);
 

--- a/src/agents/instance-agents.ts
+++ b/src/agents/instance-agents.ts
@@ -22,6 +22,7 @@ import {
     isAgent
 } from "./agent-model";
 import { AgentReference, isAgentReference } from "./agent-reference";
+import { scrubAgents } from "./agent-scrub";
 import { StaticAgentRegistry } from "./static-agent-registry";
 
 /**
@@ -156,6 +157,8 @@ export const recycleInstanceAgents = (
             am.setProperty(prop, formerValue);
         });
     }
+
+    scrubAgents(newAgents);
 
     return newAgents;
 };

--- a/src/agents/instance-agents.ts
+++ b/src/agents/instance-agents.ts
@@ -22,7 +22,6 @@ import {
     isAgent
 } from "./agent-model";
 import { AgentReference, isAgentReference } from "./agent-reference";
-import { scrubAgents } from "./agent-scrub";
 import { StaticAgentRegistry } from "./static-agent-registry";
 
 /**
@@ -157,8 +156,6 @@ export const recycleInstanceAgents = (
             am.setProperty(prop, formerValue);
         });
     }
-
-    scrubAgents(newAgents);
 
     return newAgents;
 };

--- a/src/game-api.ts
+++ b/src/game-api.ts
@@ -269,10 +269,11 @@ export class Game {
             }
 
             newInstance = instance.recycle();
-            scrubAgents(newInstance.agents);
 
             const revert = buildRevertFunction(instance.agents);
             revert(newInstance);
+
+            scrubAgents(newInstance.agents);
         } catch (error) {
             err = wrapApiErrorAsRegalError(error);
         }

--- a/src/game-api.ts
+++ b/src/game-api.ts
@@ -8,7 +8,11 @@
  * Licensed under MIT License (see https://github.com/regal/regal)
  */
 
-import { buildRevertFunction, StaticAgentRegistry } from "./agents";
+import {
+    buildRevertFunction,
+    scrubAgents,
+    StaticAgentRegistry
+} from "./agents";
 import { HookManager } from "./api-hooks";
 import { GameMetadata, GameOptions, MetadataManager } from "./config";
 import { ContextManager } from "./context-manager";
@@ -191,6 +195,7 @@ export class Game {
             }
 
             newInstance = instance.recycle();
+            scrubAgents(newInstance.agents);
 
             const activatedEvent = HookManager.playerCommandHook(command);
             newInstance.events.invoke(activatedEvent);
@@ -264,6 +269,7 @@ export class Game {
             }
 
             newInstance = instance.recycle();
+            scrubAgents(newInstance.agents);
 
             const revert = buildRevertFunction(instance.agents);
             revert(newInstance);

--- a/src/game-api.ts
+++ b/src/game-api.ts
@@ -272,8 +272,6 @@ export class Game {
 
             const revert = buildRevertFunction(instance.agents);
             revert(newInstance);
-
-            scrubAgents(newInstance.agents);
         } catch (error) {
             err = wrapApiErrorAsRegalError(error);
         }

--- a/test/unit/agents.test.ts
+++ b/test/unit/agents.test.ts
@@ -545,6 +545,7 @@ describe("Agents", function() {
                 })(myGame);
 
                 expect(myGame.agents).to.deep.equal({
+                    _nextId: 2,
                     game: myGame,
                     0: {
                         id: 0,
@@ -619,6 +620,7 @@ describe("Agents", function() {
                 })(myGame);
 
                 expect(myGame.agents).to.deep.equal({
+                    _nextId: 2,
                     game: myGame,
                     0: {
                         id: 0,
@@ -751,6 +753,7 @@ describe("Agents", function() {
                 })(myGame);
 
                 expect(myGame.agents).to.deep.equal({
+                    _nextId: 5,
                     game: myGame,
                     0: {
                         id: 0,
@@ -1170,6 +1173,7 @@ describe("Agents", function() {
                 myGame.state.arr = arr;
 
                 expect(myGame.agents).to.deep.equal({
+                    _nextId: 10,
                     game: myGame,
                     0: {
                         id: 0,
@@ -1864,6 +1868,7 @@ describe("Agents", function() {
 
             // Verify initial condition
             expect(myGame.agents).to.deep.equal({
+                _nextId: 2,
                 game: myGame,
                 0: {
                     id: 0,
@@ -1923,6 +1928,7 @@ describe("Agents", function() {
             const myGame2 = myGame.recycle();
 
             expect(myGame2.agents).to.deep.equal({
+                _nextId: 2,
                 game: myGame2,
                 0: {
                     id: 0,
@@ -1990,6 +1996,7 @@ describe("Agents", function() {
 
             // Verify initial condition
             expect(myGame.agents).to.deep.equal({
+                _nextId: 2,
                 game: myGame,
                 0: {
                     id: 0,
@@ -2042,6 +2049,7 @@ describe("Agents", function() {
             const myGame2 = myGame.recycle();
 
             expect(myGame2.agents).to.deep.equal({
+                _nextId: 2,
                 game: myGame2,
                 0: {
                     id: 0,
@@ -2112,6 +2120,7 @@ describe("Agents", function() {
             const game2 = myGame.recycle();
 
             expect(game2.agents).to.deep.equal({
+                _nextId: 2,
                 game: game2,
                 0: {
                     id: 0,
@@ -2171,6 +2180,7 @@ describe("Agents", function() {
             const game2 = myGame.recycle();
 
             expect(game2.agents).to.deep.equal({
+                _nextId: 2,
                 game: game2,
                 0: {
                     id: 0,
@@ -2222,6 +2232,7 @@ describe("Agents", function() {
             const game2 = myGame.recycle();
 
             expect(game2.agents).to.deep.equal({
+                _nextId: 2,
                 game: game2,
                 0: {
                     id: 0,
@@ -2833,5 +2844,9 @@ describe("Agents", function() {
             expect(res.state.agents[0].name).to.equal("D0");
             expect(res.state.agents[5].name).to.equal("D5");
         });
+    });
+
+    describe("Scrubbing", function() {
+        it("Scrubbing an InstanceAgents deletes all agents that have no references to them", function() {});
     });
 });

--- a/test/unit/agents.test.ts
+++ b/test/unit/agents.test.ts
@@ -2882,7 +2882,46 @@ describe("Agents", function() {
                 }
             });
 
-            expect(() => myGame.agents.getAgentProperty(3, "name")).to.throw(RegalError, "No agent with the id <3> exists.");
+            expect(() => myGame.agents.getAgentProperty(3, "name")).to.throw(
+                RegalError,
+                "No agent with the id <3> exists."
+            );
+        });
+
+        it("Scrubbing an InstanceAgents finds agent array references", function() {
+            Game.init();
+            const myGame = new GameInstance();
+
+            const p = myGame.using(
+                new MultiParent([new Dummy("D1", 1), new Dummy("D2", 2)])
+            );
+            myGame.state.arr = [true, new Dummy("D3", 3), p, p.children[0]];
+
+            expect(
+                myGame.agents.agentManagers().map(am => am.id)
+            ).to.deep.equal([0, 1, 2, 3, 4, 5, 6]);
+            expect(myGame.state.arr[3]).to.deep.equal({
+                id: 3,
+                name: "D1",
+                health: 1
+            });
+
+            scrubAgents(myGame.agents);
+            expect(
+                myGame.agents.agentManagers().map(am => am.id)
+            ).to.deep.equal([0, 1, 2, 3, 4, 5, 6]);
+
+            (myGame.state.arr as any[]).splice(2, 1);
+            scrubAgents(myGame.agents);
+
+            expect(
+                myGame.agents.agentManagers().map(am => am.id)
+            ).to.deep.equal([0, 3, 5, 6]);
+            expect(myGame.state.arr[2]).to.deep.equal({
+                id: 3,
+                name: "D1",
+                health: 1
+            });
         });
     });
 });

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -231,6 +231,7 @@ describe("Config", function() {
                 });
 
                 expect(response.instance.agents).to.deep.equal({
+                    _nextId: 1,
                     game: response.instance,
                     "0": {
                         id: 0,
@@ -271,6 +272,7 @@ describe("Config", function() {
                 response = Game.postPlayerCommand(response.instance, "Lars");
 
                 expect(response.instance.agents).to.deep.equal({
+                    _nextId: 2,
                     game: response.instance,
                     "0": {
                         id: 0,
@@ -407,6 +409,7 @@ describe("Config", function() {
                 response = Game.postPlayerCommand(response.instance, "Jeffrey");
 
                 expect(response.instance.agents).to.deep.equal({
+                    _nextId: 3,
                     game: response.instance,
                     "0": {
                         id: 0,
@@ -578,6 +581,7 @@ describe("Config", function() {
                 });
 
                 expect(response.instance.agents).to.deep.equal({
+                    _nextId: 1,
                     game: response.instance,
                     "0": {
                         id: 0,
@@ -609,6 +613,7 @@ describe("Config", function() {
                 response = Game.postPlayerCommand(response.instance, "Lars");
 
                 expect(response.instance.agents).to.deep.equal({
+                    _nextId: 2,
                     game: response.instance,
                     "0": {
                         id: 0,
@@ -685,6 +690,7 @@ describe("Config", function() {
                 response = Game.postPlayerCommand(response.instance, "Jeffrey");
 
                 expect(response.instance.agents).to.deep.equal({
+                    _nextId: 3,
                     game: response.instance,
                     "0": {
                         id: 0,

--- a/test/unit/game-api.test.ts
+++ b/test/unit/game-api.test.ts
@@ -9,7 +9,7 @@ import {
 } from "../../src/api-hooks";
 import { noop } from "../../src/events";
 import GameInstance from "../../src/game-instance";
-import { OutputLineType } from "../../src/output";
+import { OutputLineType, GameOutput, InstanceOutput } from "../../src/output";
 import { log, getDemoMetadata, metadataWithOptions } from "../test-utils";
 import { Agent } from "../../src/agents";
 import {
@@ -181,6 +181,90 @@ describe("Game API", function() {
                 "RegalError: An error occurred while executing the request. Details: <TypeError: 5.push is not a function>"
             );
             expect(response.instance).to.be.undefined;
+        });
+
+        it("The GameInstance is scrubbed before a new player command is applied", function() {
+            const printDummyNames = (dums: Dummy[], output: InstanceOutput) => {
+                output.write(`Dummies: ${dums.map(d => d.name).join(", ")}.`);
+            };
+            onStartCommand(game => {
+                game.state.arr = [new Dummy("D1", 10), new Dummy("D2", 15)];
+                printDummyNames(game.state.arr as Dummy[], game.output);
+                return noop;
+            });
+
+            onPlayerCommand(() => game => {
+                const arr = game.state.arr as Dummy[];
+                arr.pop();
+                printDummyNames(arr, game.output);
+                return noop;
+            });
+
+            const r1 = Game.postStartCommand();
+
+            expect(
+                r1.instance.agents.agentManagers().map(am => am.id)
+            ).to.deep.equal([0, 1, 2, 3]);
+
+            expect(r1.output).to.deep.equal({
+                wasSuccessful: true,
+                log: [
+                    {
+                        data: "Dummies: D1, D2.",
+                        id: 1,
+                        type: OutputLineType.NORMAL
+                    }
+                ]
+            });
+
+            const r2 = Game.postPlayerCommand(r1.instance, "");
+
+            expect(
+                r1.instance.agents.agentManagers().map(am => am.id)
+            ).to.deep.equal([0, 1, 2, 3]);
+            expect(
+                r2.instance.agents.agentManagers().map(am => am.id)
+            ).to.deep.equal([0, 1, 2, 3]);
+
+            expect(r2.output).to.deep.equal({
+                wasSuccessful: true,
+                log: [
+                    {
+                        data: "Dummies: D1.",
+                        id: 2,
+                        type: OutputLineType.NORMAL
+                    }
+                ]
+            });
+
+            const r3 = Game.postPlayerCommand(r2.instance, "");
+
+            expect(
+                r2.instance.agents.agentManagers().map(am => am.id)
+            ).to.deep.equal([0, 1, 2, 3]);
+            expect(
+                r3.instance.agents.agentManagers().map(am => am.id)
+            ).to.deep.equal([0, 1, 2]);
+
+            expect(r3.output).to.deep.equal({
+                wasSuccessful: true,
+                log: [
+                    {
+                        data: "Dummies: .",
+                        id: 3,
+                        type: OutputLineType.NORMAL
+                    }
+                ]
+            });
+
+            const r4 = Game.postPlayerCommand(r3.instance, "");
+
+            expect(
+                r3.instance.agents.agentManagers().map(am => am.id)
+            ).to.deep.equal([0, 1, 2]);
+            expect(
+                r4.instance.agents.agentManagers().map(am => am.id)
+            ).to.deep.equal([0, 1]);
         });
     });
 
@@ -421,6 +505,90 @@ describe("Game API", function() {
             );
             expect(undoResponse.instance).to.be.undefined;
         });
+
+        it("Scrubbing doesn't get in the way of undoing", function() {
+            onStartCommand(game => {
+                game.state.arr = [new Dummy("D1", 10), new Dummy("D2", 15)];
+                return noop;
+            });
+
+            onPlayerCommand(() => game => {
+                const arr = game.state.arr as Dummy[];
+                arr.pop();
+                return noop;
+            });
+
+            const r1 = Game.postStartCommand();
+
+            expect(
+                r1.instance.agents.agentManagers().map(am => am.id)
+            ).to.deep.equal([0, 1, 2, 3]);
+            expect(
+                r1.instance.agents.getAgentProperty(0, "arr").length
+            ).to.equal(2);
+
+            const r2 = Game.postPlayerCommand(r1.instance, "");
+
+            expect(
+                r1.instance.agents.agentManagers().map(am => am.id)
+            ).to.deep.equal([0, 1, 2, 3]);
+            expect(
+                r2.instance.agents.agentManagers().map(am => am.id)
+            ).to.deep.equal([0, 1, 2, 3]);
+            expect(
+                r2.instance.agents.getAgentProperty(0, "arr").length
+            ).to.equal(1);
+
+            const r3 = Game.postUndoCommand(r2.instance);
+
+            expect(
+                r3.instance.agents.agentManagers().map(am => am.id)
+            ).to.deep.equal([0, 1, 2, 3]);
+            expect(
+                r3.instance.agents.getAgentProperty(0, "arr").length
+            ).to.equal(2);
+
+            const r4 = Game.postPlayerCommand(r3.instance, "");
+
+            expect(
+                r4.instance.agents.agentManagers().map(am => am.id)
+            ).to.deep.equal([0, 1, 2, 3]);
+            expect(
+                r4.instance.agents.getAgentProperty(0, "arr").length
+            ).to.equal(1);
+        });
+
+        it("Undo an undo", function() {
+            onStartCommand(game => {
+                game.state.str = "";
+                return noop;
+            });
+
+            onPlayerCommand(cmd => game => {
+                game.state.str += cmd;
+                return noop;
+            });
+
+            const r1 = Game.postStartCommand();
+            expect(r1.instance.state.str).to.equal("");
+
+            const r2 = Game.postPlayerCommand(r1.instance, "foo");
+            expect(r2.instance.state.str).to.equal("foo");
+
+            const r3 = Game.postPlayerCommand(r2.instance, "bar");
+            expect(r3.instance.state.str).to.equal("foobar");
+
+            const r4 = Game.postUndoCommand(r3.instance);
+            expect(r4.instance.state.str).to.equal("foo");
+
+            const r5 = Game.postUndoCommand(r4.instance);
+            expect(r5.instance.state.str).to.equal("foobar");
+
+            const r6 = Game.postUndoCommand(r5.instance);
+            expect(r6.instance.state.str).to.equal("foo");
+        });
+
+        // todo test undoing an undo with agent references
     });
 
     describe("Game.getMetadataCommand", function() {


### PR DESCRIPTION
## Changes
* Added `scrubAgents` function, which deletes all agents that are not part of the reference tree starting at the `GameInstance`'s state
* `scrubAgents` is called from `Game.postPlayerCommand`, after the instance is cycled but before the command is executed.

## Related Issues
* Resolves #47 