### PR TITLE
fix(event): EventQueues can be invoked like any other EventFunction

### DIFF
--- a/test/unit/events.test.ts
+++ b/test/unit/events.test.ts
@@ -364,16 +364,16 @@ describe("Events", function() {
             ]);
         });
 
-        it("Attempting to invoke an EventQueue throws an error", function() {
-            const nonevent = on("FOO", game => noop);
-            const queue = nq(nonevent, nonevent);
+        it("Invoking an EventQueue does not throw an error", function() {
+            const spam = on("SPAM", game => {
+                game.output.write("Get spammed.");
+            });
 
             Game.init();
 
-            expect(() => queue(new GameInstance())).to.throw(
-                RegalError,
-                "Cannot invoke an EventQueue."
-            );
+            const myGame = new GameInstance();
+
+            spam.then(spam)(myGame);
         });
 
         describe("QTests", function() {

--- a/test/unit/events.test.ts
+++ b/test/unit/events.test.ts
@@ -364,7 +364,7 @@ describe("Events", function() {
             ]);
         });
 
-        it("Invoking an EventQueue does not throw an error", function() {
+        it("Invoking an EventQueue works just like any other EventFunction", function() {
             const spam = on("SPAM", game => {
                 game.output.write("Get spammed.");
             });
@@ -374,6 +374,11 @@ describe("Events", function() {
             const myGame = new GameInstance();
 
             spam.then(spam)(myGame);
+
+            expect(myGame.output.lines).to.deep.equal([
+                { data: "Get spammed.", id: 1, type: OutputLineType.NORMAL },
+                { data: "Get spammed.", id: 2, type: OutputLineType.NORMAL }
+            ]);
         });
 
         describe("QTests", function() {


### PR DESCRIPTION
## Changes
* Modified `buildEventQueue` function to allow them to be invocable just like any other `EventFunction`.

## Related Issues
* Resolves #30 