### PR TITLE
feat(config): Add libraryVersion metadata property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4458,6 +4458,15 @@
         "rollup-pluginutils": "^2.3.0"
       }
     },
+    "rollup-plugin-json": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-json/-/rollup-plugin-json-3.1.0.tgz",
+      "integrity": "sha512-BlYk5VspvGpjz7lAwArVzBXR60JK+4EKtPkCHouAWg39obk9S61hZYJDBfMK+oitPdoe11i69TlxKlMQNFC/Uw==",
+      "dev": true,
+      "requires": {
+        "rollup-pluginutils": "^2.3.1"
+      }
+    },
     "rollup-plugin-node-resolve": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "readline": "^1.3.0",
     "rollup": "^0.67.3",
     "rollup-plugin-cleanup": "^3.0.0",
+    "rollup-plugin-json": "^3.1.0",
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-plugin-terser": "^2.0.2",
     "rollup-plugin-typescript2": "^0.18.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ import typescript from "rollup-plugin-typescript2";
 import resolve from "rollup-plugin-node-resolve";
 import cleanup from "rollup-plugin-cleanup";
 import { terser } from "rollup-plugin-terser";
+import json from "rollup-plugin-json";
 
 import pkg from "./package.json";
 
@@ -21,9 +22,7 @@ const supressCircularImportWarnings = (message, defaultFunc) => {
 
 const tsPlugin = typescript({
     tsconfigOverride: {
-        compilerOptions: {
-            module: "ES2015"
-        }
+        compilerOptions: { module: "ES2015" }
     }
 });
 
@@ -35,6 +34,7 @@ export default [
             { file: pkg.module, format: "esm", banner }
         ],
         plugins: [
+            json({ include: "package.json" }),
             tsPlugin,
             resolve(),
             cleanup({
@@ -49,6 +49,7 @@ export default [
         input: "./src/index.ts",
         output: { file: pkg.browser, format: "umd", name: "Regal" },
         plugins: [
+            json({ include: "package.json" }),
             tsPlugin,
             resolve(),
             terser({

--- a/src/config/game-metadata.ts
+++ b/src/config/game-metadata.ts
@@ -33,4 +33,7 @@ export interface GameMetadata {
 
     /** Any options defined in the game's static configuration. */
     readonly options: Partial<GameOptions>;
+
+    /** The version of the Regal Game Library used by the game. */
+    readonly regalVersion?: string;
 }

--- a/src/config/metadata-manager.ts
+++ b/src/config/metadata-manager.ts
@@ -5,6 +5,7 @@
  * Licensed under MIT License (see https://github.com/regal/regal)
  */
 
+import { version as regalVersion } from "../../package.json";
 import { RegalError } from "../error";
 import { GameMetadata } from "./game-metadata";
 
@@ -33,7 +34,22 @@ export class MetadataManager {
      * @param metadata The game's metadata.
      */
     public static setMetadata(metadata: GameMetadata): void {
-        MetadataManager._metadata = metadata;
+        if (metadata.regalVersion !== undefined) {
+            throw new RegalError(
+                "regalVersion is specified internally and may not be modified."
+            );
+        }
+
+        MetadataManager._metadata = {
+            author: metadata.author,
+            description: metadata.description,
+            headline: metadata.headline,
+            homepage: metadata.homepage,
+            name: metadata.name,
+            options: metadata.options,
+            regalVersion,
+            repository: metadata.repository
+        };
     }
 
     /**

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -1,5 +1,6 @@
 import { inspect } from "util";
 import { GameMetadata, GameOptions } from "../src/config";
+import { version as regalVersion } from "../package.json";
 
 export const log = (o: any, title?: string) =>
     console.log(
@@ -22,7 +23,15 @@ export const metadataWithOptions = (opts: Partial<GameOptions>) => {
     return metadata;
 };
 
-// Throw this in the promise resolve argument for tests that should have failed promises
-export const expectedPromiseFailure = () => {
-    throw new Error("Promise was supposed to fail.");
-};
+export const metadataWithVersion = (metadata: GameMetadata): GameMetadata => ({
+    author: metadata.author,
+    description: metadata.description,
+    headline: metadata.headline,
+    homepage: metadata.homepage,
+    name: metadata.name,
+    options: metadata.options,
+    regalVersion,
+    repository: metadata.repository
+});
+
+export const libraryVersion = regalVersion;

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,7 @@
+// TypeScript configuration for tests
+{
+    "extends": "../tsconfig.json",
+    "include": [
+        "./**/*.ts"
+    ],
+}

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -9,7 +9,13 @@ import {
     ensureOverridesAllowed
 } from "../../src/config";
 import { OutputLineType } from "../../src/output";
-import { getDemoMetadata, metadataWithOptions, log } from "../test-utils";
+import {
+    getDemoMetadata,
+    metadataWithOptions,
+    log,
+    libraryVersion,
+    metadataWithVersion
+} from "../test-utils";
 import { on } from "../../src/events";
 import { Agent, PropertyOperation } from "../../src/agents";
 import { Game, onStartCommand, onPlayerCommand } from "../../src/api";
@@ -923,6 +929,30 @@ describe("Config", function() {
             expect(() => MetadataManager.getMetadata()).to.throw(
                 RegalError,
                 "Metadata is not defined. Did you remember to load the config?"
+            );
+        });
+
+        it("regalVersion is set automatically", function() {
+            MetadataManager.reset();
+            MetadataManager.setMetadata({
+                name: "Foo",
+                options: {}
+            });
+
+            expect(MetadataManager.getMetadata().regalVersion).to.equal(
+                libraryVersion
+            );
+        });
+
+        it("MetadataManager.setMetadata throws an error if passed a value for libraryVersion", function() {
+            MetadataManager.reset();
+            expect(() =>
+                MetadataManager.setMetadata(
+                    metadataWithVersion(getDemoMetadata())
+                )
+            ).to.throw(
+                RegalError,
+                "regalVersion is specified internally and may not be modified."
             );
         });
     });

--- a/test/unit/game-api.test.ts
+++ b/test/unit/game-api.test.ts
@@ -11,7 +11,12 @@ import {
 } from "../../src/api";
 import { noop } from "../../src/events";
 import { OutputLineType, InstanceOutput } from "../../src/output";
-import { log, getDemoMetadata, metadataWithOptions } from "../test-utils";
+import {
+    log,
+    getDemoMetadata,
+    metadataWithOptions,
+    metadataWithVersion
+} from "../test-utils";
 import { Agent, StaticAgentRegistry } from "../../src/agents";
 import {
     DEFAULT_GAME_OPTIONS,
@@ -63,7 +68,7 @@ describe("Game API", function() {
 
         it("Game.init sets the game's metadata", function() {
             expect(MetadataManager.getMetadata()).to.deep.equal(
-                getDemoMetadata()
+                metadataWithVersion(getDemoMetadata())
             );
         });
 
@@ -733,7 +738,9 @@ describe("Game API", function() {
 
             expect(response.instance).to.be.undefined;
             expect(response.output.wasSuccessful).to.be.true;
-            expect(response.output.metadata).to.deep.equal(getDemoMetadata());
+            expect(response.output.metadata).to.deep.equal(
+                metadataWithVersion(getDemoMetadata())
+            );
         });
 
         it("Catch the error if metadata has not been set", function() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
         "outDir": "./dist",
         "noImplicitReturns": true,
         "noFallthroughCasesInSwitch": true,
-        "sourceMap": false
+        "sourceMap": false,
+        "resolveJsonModule": true
     },
     "include": [
         "src/**/*"


### PR DESCRIPTION
## Description
* Add `libraryVersion` as a nonconfigurable metadata property that is loaded from RGL's `package.json`.
* `MetadataManager.setMetadata` throws an error if passed a value for `libraryVersion`.
* Update Rollup script to allow importing from JSON

## Related Issues
* Resolves #53 