### PR TITLE
feat: Optional type parameter for GameInstance state and EventFunctions

### DIFF
--- a/src/events/impl/event-builders.ts
+++ b/src/events/impl/event-builders.ts
@@ -17,14 +17,16 @@ import { buildEventQueue, buildThenMethod } from "./event-queue-impl";
 /**
  * Adds the events to the end of the game's event queue.
  *
- * If the events are `EventQueue`s, any events in the queues'
- * immediateEvents collections will be concatenated, followed
- * by any events in the queues' delayedEvents collections.
+ * If the events are `EventQueue`s, any events in the queues' `immediateEvents`
+ * collections will be concatenated, followed by any events in the queues' `delayedEvents`.
  *
+ * @template StateType The `GameInstance` state type. Optional, defaults to `any`.
  * @param events The events to be added.
  * @returns The `EventQueue` with all events in the queue's `delayedEvent` collection.
  */
-export const enqueue = (...events: TrackedEvent[]): EventQueue => {
+export const enqueue = <StateType = any>(
+    ...events: Array<TrackedEvent<StateType>>
+): EventQueue<StateType> => {
     const argImmediateEvents: TrackedEvent[] = [];
     const argDelayedEvents: TrackedEvent[] = [];
 
@@ -43,26 +45,33 @@ export const enqueue = (...events: TrackedEvent[]): EventQueue => {
 /**
  * Adds the events to the end of the game's event queue. (Alias of `enqueue`)
  *
- * If the events are `EventQueue`s, any events in the queues'
- * immediateEvents collections will be concatenated, followed
- * by any events in the queues' `delayedEvents` collections.
+ * If the events are `EventQueue`s, any events in the queues' `immediateEvents`
+ * collections will be concatenated, followed by any events in the queues' `delayedEvents`.
  *
+ * @template StateType The `GameInstance` state type. Optional, defaults to `any`.
  * @param events The events to be added.
  * @returns The `EventQueue` with all events in the queue's `delayedEvent` collection.
  */
 export const nq = enqueue;
 
 /**
- * Creates a `TrackedEvent` around an `EventFunction`.
+ * Constructs a `TrackedEvent`, which is a function that modifies a `GameInstance`
+ * and tracks all changes as they occur.
+ *
+ * All modifications to game state within a Regal game should take place through a `TrackedEvent`.
+ * This function is the standard way to declare a `TrackedEvent`.
+ *
+ * @template StateType The `GameInstance` state type. Optional, defaults to `any`.
  *
  * @param eventName The name of the `TrackedEvent`.
- * @param eventFunc The `EventFunction` to be tracked.
+ * @param eventFunc The function that will be executed on a `GameInstance`.
+ *
  * @returns The generated `TrackedEvent`.
  */
-export const on = (
+export const on = <StateType = any>(
     eventName: string,
-    eventFunc: EventFunction
-): TrackedEvent => {
+    eventFunc: EventFunction<StateType>
+): TrackedEvent<StateType> => {
     // Make the TrackedEvent callable like a function.
     const event = ((game: GameInstance) => {
         game.events.invoke(event);

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -10,6 +10,7 @@ export {
     EventQueue,
     noop,
     TrackedEvent,
+    GameEventBuilder,
     isEventQueue,
     isTrackedEvent
 } from "./event-types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export {
     enqueue,
     nq,
     on,
-    GameEventHandler
+    GameEventBuilder
 } from "./events";
 export {
     Game,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,8 @@ export {
     InstanceEvents,
     enqueue,
     nq,
-    on
+    on,
+    GameEventHandler
 } from "./events";
 export {
     Game,

--- a/src/state/game-instance-internal.ts
+++ b/src/state/game-instance-internal.ts
@@ -41,7 +41,7 @@ export interface GameInstanceInternal<StateType = any>
      *
      * @returns The new `GameInstanceInternal`, with each manager cycled.
      */
-    recycle(newOptions?: Partial<GameOptions>): GameInstanceInternal;
+    recycle(newOptions?: Partial<GameOptions>): GameInstanceInternal<StateType>;
 
     /**
      * Generates a new `GameInstanceInternal` that is a deep copy of the current instance
@@ -52,5 +52,5 @@ export interface GameInstanceInternal<StateType = any>
      * @param revertTo The id of the `TrackedEvent` to which the state will be reverted.
      * Defaults to zero. If nonzero and the `trackAgentChanges` option is disabled, an error will throw.
      */
-    revert(revertTo?: number): GameInstanceInternal;
+    revert(revertTo?: number): GameInstanceInternal<StateType>;
 }

--- a/src/state/game-instance-internal.ts
+++ b/src/state/game-instance-internal.ts
@@ -14,8 +14,10 @@ import { GameInstance } from "./game-instance";
 
 /**
  * Internal interface for `GameInstance`.
+ * @template StateType The state property's type. Optional, defaults to `any`.
  */
-export interface GameInstanceInternal extends GameInstance {
+export interface GameInstanceInternal<StateType = any>
+    extends GameInstance<StateType> {
     /** The internal interface to the manager for all agents in the instance. */
     agents: InstanceAgentsInternal;
 

--- a/src/state/game-instance.ts
+++ b/src/state/game-instance.ts
@@ -21,8 +21,10 @@ import { InstanceRandom } from "../random";
  *
  * Contains all APIs used by game developers to read and write
  * to the game's instance state.
+ *
+ * @template StateType The state property's type. Optional, defaults to `any`.
  */
-export interface GameInstance {
+export interface GameInstance<StateType = any> {
     /** The manager for all events in the instance. */
     events: InstanceEvents;
 
@@ -41,7 +43,7 @@ export interface GameInstance {
      * Properties set within this object are maintained between game cycles, so
      * it should be used to store long-term state.
      */
-    state: any;
+    state: StateType;
 
     /**
      * Activates one or more agents in the current game context. All agents

--- a/src/state/impl/game-instance-impl.ts
+++ b/src/state/impl/game-instance-impl.ts
@@ -35,18 +35,19 @@ import { GameInstanceInternal } from "../game-instance-internal";
 /**
  * Constructs a new `GameInstance` with optional `GameOption` overrides.
  *
+ * @template StateType The state property's type. Optional, defaults to `any`.
  * @param optOverrides Any option overrides preferred for this specific instance.
  * Must be allowed by the static configuration's `allowOverrides` option.
  */
-export const buildGameInstance = (
+export const buildGameInstance = <StateType = any>(
     optOverrides?: Partial<GameOptions>
-): GameInstanceInternal => {
+): GameInstanceInternal<StateType> => {
     if (optOverrides !== undefined) {
-        return new GameInstanceImpl({
+        return new GameInstanceImpl<StateType>({
             optionsBuilder: game => buildInstanceOptions(game, optOverrides)
         });
     }
-    return new GameInstanceImpl();
+    return new GameInstanceImpl<StateType>();
 };
 
 /**
@@ -61,13 +62,18 @@ interface GameInstanceCtor {
     randomBuilder: (game: GameInstanceInternal) => InstanceRandomInternal;
 }
 
-class GameInstanceImpl implements GameInstanceInternal {
+/**
+ * Implementation of `GameInstanceInternal`.
+ * @template StateType The state property's type. Optional, defaults to `any`.
+ */
+class GameInstanceImpl<StateType = any>
+    implements GameInstanceInternal<StateType> {
     public agents: InstanceAgentsInternal;
     public events: InstanceEventsInternal;
     public output: InstanceOutputInternal;
     public options: InstanceOptionsInternal;
     public random: InstanceRandomInternal;
-    public state: any;
+    public state: StateType;
 
     /**
      * Constructs a `GameInstanceImpl` with the given `InstanceX` constructor functions.
@@ -90,7 +96,7 @@ class GameInstanceImpl implements GameInstanceInternal {
         this.agents = agentsBuilder(this);
         this.output = outputBuilder(this);
         this.random = randomBuilder(this);
-        this.state = buildActiveAgentProxy(0, this);
+        this.state = (buildActiveAgentProxy(0, this) as unknown) as StateType;
     }
 
     public recycle(newOptions?: Partial<GameOptions>): GameInstanceImpl {

--- a/test/unit/agents.test.ts
+++ b/test/unit/agents.test.ts
@@ -458,8 +458,12 @@ describe("Agents", function() {
         });
 
         it("Activating multiple agents as a safety at the beginning of events", function() {
+            interface S {
+                parent: Parent;
+            }
+
             const newChild = (_target: Parent) =>
-                on("NEW CHILD", game => {
+                on<S>("NEW CHILD", game => {
                     const { parent, child } = game.using({
                         parent: _target,
                         child: new Dummy("D1", 10)
@@ -474,7 +478,7 @@ describe("Agents", function() {
             Game.init(MD);
 
             // Using a static agent that hasn't been activated
-            const myGame1 = buildGameInstance();
+            const myGame1 = buildGameInstance<S>();
             newChild(PARENT)(myGame1);
 
             expect(myGame1.state.parent.child.id).to.equal(3);
@@ -482,7 +486,7 @@ describe("Agents", function() {
             expect(myGame1.state.parent.child.health).to.equal(10);
 
             // Using a nonstatic agent that's been activated
-            const myGame2 = buildGameInstance();
+            const myGame2 = buildGameInstance<S>();
             const myParent = myGame2.using(new Parent(new Dummy("D2", 2)));
             newChild(myParent)(myGame2);
 
@@ -491,7 +495,7 @@ describe("Agents", function() {
             expect(myGame2.state.parent.child.health).to.equal(10);
 
             // Using a nonstatic agent that hasn't been activated
-            const myGame3 = buildGameInstance();
+            const myGame3 = buildGameInstance<S>();
             const myParent2 = new Parent(undefined);
             newChild(myParent2)(myGame3);
 
@@ -895,13 +899,17 @@ describe("Agents", function() {
             it("Setting an active agent's property to be an array of inactive agents is implicitly activates them", function() {
                 Game.init(MD);
 
-                const myGame = buildGameInstance();
-                on("MOD", game => {
+                interface S {
+                    arr: Dummy[];
+                }
+
+                const myGame = buildGameInstance<S>();
+                on<S>("MOD", game => {
                     game.state.arr = [new Dummy("D1", 10), new Dummy("D2", 15)];
                 })(myGame);
 
-                const d1 = myGame.state.arr[0] as Dummy;
-                const d2 = myGame.state.arr[1] as Dummy;
+                const d1 = myGame.state.arr[0];
+                const d2 = myGame.state.arr[1];
 
                 expect(d1.id).to.equal(2);
                 expect(d1.name).to.equal("D1");
@@ -2678,7 +2686,7 @@ describe("Agents", function() {
 
         it("Scrubbing an InstanceAgents finds agent array references", function() {
             Game.init(MD);
-            const myGame = buildGameInstance();
+            const myGame = buildGameInstance<{ arr: any[] }>();
 
             const p = myGame.using(
                 new MultiParent([new Dummy("D1", 1), new Dummy("D2", 2)])
@@ -2699,7 +2707,7 @@ describe("Agents", function() {
                 myGame.agents.agentManagers().map(am => am.id)
             ).to.deep.equal([0, 1, 2, 3, 4, 5, 6]);
 
-            (myGame.state.arr as any[]).splice(2, 1);
+            myGame.state.arr.splice(2, 1);
             myGame.agents.scrubAgents();
 
             expect(

--- a/test/unit/game-instance.test.ts
+++ b/test/unit/game-instance.test.ts
@@ -31,8 +31,9 @@ describe("GameInstance", function() {
         );
     });
 
-    it("buildGameInstance can have a parameterized state", function() {
+    it("Compile Check: buildGameInstance can have a parameterized state", function() {
         interface CustomState {
+            /** test parm */
             a: boolean;
         }
 

--- a/test/unit/game-instance.test.ts
+++ b/test/unit/game-instance.test.ts
@@ -31,6 +31,15 @@ describe("GameInstance", function() {
         );
     });
 
+    it("buildGameInstance can have a parameterized state", function() {
+        interface CustomState {
+            a: boolean;
+        }
+
+        const myGame = buildGameInstance<CustomState>();
+        myGame.state.a = true; // Compiles
+    });
+
     describe("Recycle", function() {
         it("Cycling a new GameInstance is equivalent to instantiating a new one", function() {
             const game = buildGameInstance({ seed: "foo" });

--- a/test/unit/random.test.ts
+++ b/test/unit/random.test.ts
@@ -322,23 +322,27 @@ describe("Random", function() {
         });
 
         it("Generated values are recorded in InstanceEvent's EventRecord history", function() {
-            const rand1 = on("RAND1", game => {
+            interface S {
+                randos: any[];
+            }
+
+            const rand1 = on<S>("RAND1", game => {
                 game.state.randos = [];
-                const randos = game.state.randos as any[];
+                const randos = game.state.randos;
 
                 randos.push(game.random.boolean());
                 randos.push(game.random.decimal());
             });
 
-            const rand2 = on("RAND2", game => {
-                const randos = game.state.randos as any[];
+            const rand2 = on<S>("RAND2", game => {
+                const randos = game.state.randos;
 
                 randos.push(game.random.int(1, 10));
                 randos.push(game.random.string(5));
                 randos.push(game.random.choice(randos));
             });
 
-            const myGame = buildGameInstance({ seed: "wooof" });
+            const myGame = buildGameInstance<S>({ seed: "wooof" });
             rand1.then(rand2)(myGame);
 
             expect(myGame.state.randos).to.deep.equal([


### PR DESCRIPTION
## Description
* Add `<StateType = any>` generic parameter to `GameInstance`, `EventFunction`, `on`, and others to allow optional parameterization of `GameInstance.state`.
* Create `GameEventBuilder` type alias for convenience of declaring a parameterized `on` function.
* Refactor a few tests to use parameterized state.

## Related Issues
* Resolves #77 