### PR TITLE
fix(api): Refactor Game API

### DIFF
--- a/src/api/api-hook-manager.ts
+++ b/src/api/api-hook-manager.ts
@@ -8,7 +8,7 @@
 
 import { TrackedEvent } from "../events";
 import { GameInstance } from "../state";
-import { returnTrue } from "./api-hooks";
+import { returnTrue } from "./impl";
 
 /**
  * Manager for the Game's API hooks.

--- a/src/api/game-api-extended.ts
+++ b/src/api/game-api-extended.ts
@@ -1,0 +1,31 @@
+/*
+ * Contains the extended Game API interface.
+ *
+ * Copyright (c) 2018 Joseph R Cowman
+ * Licensed under MIT License (see https://github.com/regal/regal)
+ */
+
+import { GameMetadata } from "../config";
+import { GameApi } from "./game-api";
+
+/**
+ * API for interacting with the Regal game.
+ *
+ * Contains the standard methods from `GameApi`, as well as additional
+ * methods for advanced control.
+ */
+export interface GameApiExtended extends GameApi {
+    /** Whether `Game.init` has been called. */
+    isInitialized(): boolean;
+
+    /**
+     * Initializes the game with the given metadata.
+     * This must be called before any game commands may be executed.
+     *
+     * @param metadata The game's configuration metadata.
+     */
+    init(metadata: GameMetadata): void;
+
+    /** Resets the game's static classes. */
+    reset(): void;
+}

--- a/src/api/game-api-extended.ts
+++ b/src/api/game-api-extended.ts
@@ -1,5 +1,5 @@
 /*
- * Contains the extended Game API interface.
+ * Contains the extended Game API.
  *
  * Copyright (c) 2018 Joseph R Cowman
  * Licensed under MIT License (see https://github.com/regal/regal)

--- a/src/api/game-api.ts
+++ b/src/api/game-api.ts
@@ -8,135 +8,14 @@
  * Licensed under MIT License (see https://github.com/regal/regal)
  */
 
-import { StaticAgentRegistry } from "../agents";
-import { GameMetadata, GameOptions, MetadataManager } from "../config";
-import { RegalError } from "../error";
-import {
-    buildGameInstance,
-    ContextManager,
-    GameInstance,
-    GameInstanceInternal
-} from "../state";
-import { HookManager } from "./api-hook-manager";
-import { GameResponse, GameResponseOutput } from "./game-response";
+import { GameOptions } from "../config";
+import { GameInstance } from "../state";
+import { GameResponse } from "./game-response";
 
 /**
- * Throws an error if `instance` or any of its properties are undefined.
- * @param instance The `GameInstance` to validate.
+ * Public API for interacting with the Regal game.
  */
-const validateGameInstance = (instance: GameInstanceInternal): void => {
-    if (
-        instance === undefined ||
-        instance.agents === undefined ||
-        instance.events === undefined ||
-        instance.output === undefined ||
-        instance.state === undefined
-    ) {
-        throw new RegalError("Invalid GameInstance.");
-    }
-};
-
-/**
- * Wraps an error into a `RegalError` (if it's not already) that is
- * parseable by a `GameResponse`.
- *
- * @param err Some error object; should have `name`, `stack`, and `message` properties.
- */
-const wrapApiErrorAsRegalError = (err: any): RegalError => {
-    if (!err || !err.name || !err.stack || !err.message) {
-        return new RegalError("Invalid error object.");
-    }
-
-    // If err is already a RegalError, return it
-    if (err.message.indexOf("RegalError:") !== -1) {
-        return err;
-    }
-
-    // Else, create a RegalError
-    const msg = `An error occurred while executing the request. Details: <${
-        err.name
-    }: ${err.message}>`;
-    const newErr = new RegalError(msg);
-    newErr.stack = err.stack;
-
-    return newErr;
-};
-
-/**
- * Helper function to build a `GameResponse` based on the return values of
- * `Game.postPlayerCommand` or `Game.postStartCommand`, including any output logs.
- *
- * @param err Any error that was thrown. If defined, the response will be considered failed.
- * @param newInstance The new `GameInstance` to be returned to the client.
- */
-const buildLogResponse = (
-    err: RegalError,
-    newInstance: GameInstance
-): GameResponse => {
-    let response: GameResponse;
-
-    if (err !== undefined) {
-        const output: GameResponseOutput = {
-            error: err,
-            wasSuccessful: false
-        };
-        response = {
-            output
-        };
-    } else {
-        const output: GameResponseOutput = {
-            log: newInstance.output.lines,
-            wasSuccessful: true
-        };
-        response = {
-            instance: newInstance,
-            output
-        };
-    }
-
-    return response;
-};
-
-const NOT_INITALIZED_ERROR_MSG =
-    "Game has not been initalized. Did you remember to call Game.init?";
-
-/**
- * Game API static class.
- *
- * Each method returns a `GameResponse` and does not modify
- * any arguments passed into it.
- */
-export class Game {
-    /** Whether `Game.init` has been called. */
-    public static get isInitialized() {
-        return this._isInitialized;
-    }
-
-    /**
-     * Initializes the game with the given metadata.
-     * This must be called before any game commands may be executed.
-     *
-     * @param metadata The game's configuration metadata.
-     */
-    public static init(metadata: GameMetadata): void {
-        if (Game._isInitialized) {
-            throw new RegalError("Game has already been initialized.");
-        }
-        Game._isInitialized = true;
-
-        ContextManager.init();
-        MetadataManager.setMetadata(metadata);
-    }
-
-    /** Resets the game's static classes. */
-    public static reset(): void {
-        Game._isInitialized = false;
-        ContextManager.reset();
-        HookManager.reset();
-        StaticAgentRegistry.reset();
-        MetadataManager.reset();
-    }
-
+export interface GameApi {
     /**
      * Gets the game's metadata. Note that this is not specific
      * to any `GameInstance`, but refers to the game's static context.
@@ -144,26 +23,7 @@ export class Game {
      * @returns A `GameResponse` containing the game's metadata as output,
      * if the request was successful. Otherwise, the response will contain an error.
      */
-    public static getMetadataCommand(): GameResponse {
-        let metadata: GameMetadata;
-        let err: RegalError;
-
-        try {
-            if (!Game._isInitialized) {
-                throw new RegalError(NOT_INITALIZED_ERROR_MSG);
-            }
-            metadata = MetadataManager.getMetadata();
-        } catch (error) {
-            err = wrapApiErrorAsRegalError(error);
-        }
-
-        const output =
-            err !== undefined
-                ? { error: err, wasSuccessful: false }
-                : { metadata, wasSuccessful: true };
-
-        return { output };
-    }
+    getMetadataCommand(): GameResponse;
 
     /**
      * Submits a command that was entered by the player, usually to trigger
@@ -179,40 +39,7 @@ export class Game {
      * values and any output logged during the game cycle's events, if the request
      * was successful. Otherwise, the response will contain an error.
      */
-    public static postPlayerCommand(
-        instance: GameInstance,
-        command: string
-    ): GameResponse {
-        let newInstance: GameInstanceInternal;
-        let err: RegalError;
-
-        try {
-            if (!Game._isInitialized) {
-                throw new RegalError(NOT_INITALIZED_ERROR_MSG);
-            }
-            const oldInstance = instance as GameInstanceInternal;
-            validateGameInstance(oldInstance);
-
-            if (command === undefined) {
-                throw new RegalError("Command must be defined.");
-            }
-            if (HookManager.playerCommandHook === undefined) {
-                throw new RegalError(
-                    "onPlayerCommand has not been implemented by the game developer."
-                );
-            }
-
-            newInstance = oldInstance.recycle();
-            newInstance.agents.scrubAgents();
-
-            const activatedEvent = HookManager.playerCommandHook(command);
-            newInstance.events.invoke(activatedEvent);
-        } catch (error) {
-            err = wrapApiErrorAsRegalError(error);
-        }
-
-        return buildLogResponse(err, newInstance);
-    }
+    postPlayerCommand(instance: GameInstance, command: string): GameResponse;
 
     /**
      * Triggers the start of a new game instance.
@@ -227,30 +54,7 @@ export class Game {
      * logged during the game cycle's events, if the request was successful.
      * Otherwise, the response will contain an error.
      */
-    public static postStartCommand(
-        options: Partial<GameOptions> = {}
-    ): GameResponse {
-        let newInstance: GameInstance;
-        let err: RegalError;
-
-        try {
-            if (!Game._isInitialized) {
-                throw new RegalError(NOT_INITALIZED_ERROR_MSG);
-            }
-            if (HookManager.startCommandHook === undefined) {
-                throw new RegalError(
-                    "onStartCommand has not been implemented by the game developer."
-                );
-            }
-
-            newInstance = buildGameInstance(options);
-            newInstance.events.invoke(HookManager.startCommandHook);
-        } catch (error) {
-            err = wrapApiErrorAsRegalError(error);
-        }
-
-        return buildLogResponse(err, newInstance);
-    }
+    postStartCommand(options?: Partial<GameOptions>): GameResponse;
 
     /**
      * Reverts the effects of the last command that modified the game instance.
@@ -264,40 +68,7 @@ export class Game {
      * @returns A `GameResponse` containing a new `GameInstance` with updated
      * values, if the request was successful. Otherwise, the response will contain an error.
      */
-    public static postUndoCommand(instance: GameInstance): GameResponse {
-        let newInstance: GameInstanceInternal;
-        let err: RegalError;
-
-        try {
-            if (!Game._isInitialized) {
-                throw new RegalError(NOT_INITALIZED_ERROR_MSG);
-            }
-            const oldInstance = instance as GameInstanceInternal;
-            validateGameInstance(oldInstance);
-
-            if (!HookManager.beforeUndoCommandHook(instance)) {
-                throw new RegalError("Undo is not allowed here.");
-            }
-
-            newInstance = oldInstance.revert();
-        } catch (error) {
-            err = wrapApiErrorAsRegalError(error);
-        }
-
-        return err !== undefined
-            ? {
-                  output: {
-                      error: err,
-                      wasSuccessful: false
-                  }
-              }
-            : {
-                  instance: newInstance,
-                  output: {
-                      wasSuccessful: true
-                  }
-              };
-    }
+    postUndoCommand(instance: GameInstance): GameResponse;
 
     /**
      * Updates the values of the named game options in the `GameInstance`.
@@ -309,50 +80,8 @@ export class Game {
      * @returns A `GameResponse` containing a new `GameInstance` with updated
      * options, if the request was successful. Otherwise, the response will contain an error.
      */
-    public static postOptionCommand(
+    postOptionCommand(
         instance: GameInstance,
         options: Partial<GameOptions>
-    ): GameResponse {
-        let newInstance: GameInstanceInternal;
-        let err: RegalError;
-
-        try {
-            if (!Game._isInitialized) {
-                throw new RegalError(NOT_INITALIZED_ERROR_MSG);
-            }
-            const oldInstance = instance as GameInstanceInternal;
-            validateGameInstance(oldInstance);
-
-            const oldOverrideKeys = Object.keys(oldInstance.options.overrides);
-            const newOptionKeys = Object.keys(options);
-
-            const newOptions: Partial<GameOptions> = {};
-
-            oldOverrideKeys
-                .filter(key => !newOptionKeys.includes(key))
-                .forEach(key => (newOptions[key] = oldInstance.options[key]));
-            newOptionKeys.forEach(key => (newOptions[key] = options[key]));
-
-            newInstance = oldInstance.recycle(newOptions);
-        } catch (error) {
-            err = wrapApiErrorAsRegalError(error);
-        }
-
-        return err !== undefined
-            ? {
-                  output: {
-                      error: err,
-                      wasSuccessful: false
-                  }
-              }
-            : {
-                  instance: newInstance,
-                  output: {
-                      wasSuccessful: true
-                  }
-              };
-    }
-
-    /** Internal variable to track whether Game.init has been called. */
-    private static _isInitialized: boolean = false;
+    ): GameResponse;
 }

--- a/src/api/impl/api-hooks.ts
+++ b/src/api/impl/api-hooks.ts
@@ -9,10 +9,10 @@
  * Licensed under MIT License (see https://github.com/regal/regal)
  */
 
-import { RegalError } from "../error";
-import { EventFunction, isTrackedEvent, on } from "../events";
-import { GameInstance } from "../state";
-import { HookManager } from "./api-hook-manager";
+import { RegalError } from "../../error";
+import { EventFunction, isTrackedEvent, on } from "../../events";
+import { GameInstance } from "../../state";
+import { HookManager } from "../api-hook-manager";
 
 /** Default implementation of `beforeUndoCommandHook`; always returns true. */
 export const returnTrue = (game: GameInstance) => true;

--- a/src/api/impl/game-impl.ts
+++ b/src/api/impl/game-impl.ts
@@ -1,0 +1,288 @@
+/*
+ * Contains the `Game` object that is used to implement `GameApiExtended`.
+ *
+ * Copyright (c) 2018 Joseph R Cowman
+ * Licensed under MIT License (see https://github.com/regal/regal)
+ */
+
+import { StaticAgentRegistry } from "../../agents";
+import { GameMetadata, GameOptions, MetadataManager } from "../../config";
+import { RegalError } from "../../error";
+import {
+    buildGameInstance,
+    ContextManager,
+    GameInstance,
+    GameInstanceInternal
+} from "../../state";
+import { HookManager } from "../api-hook-manager";
+import { GameApiExtended } from "../game-api-extended";
+import { GameResponse, GameResponseOutput } from "../game-response";
+
+/**
+ * Throws an error if `instance` or any of its properties are undefined.
+ * @param instance The `GameInstance` to validate.
+ */
+const validateGameInstance = (instance: GameInstanceInternal): void => {
+    if (
+        instance === undefined ||
+        instance.agents === undefined ||
+        instance.events === undefined ||
+        instance.output === undefined ||
+        instance.state === undefined
+    ) {
+        throw new RegalError("Invalid GameInstance.");
+    }
+};
+
+/**
+ * Wraps an error into a `RegalError` (if it's not already) that is
+ * parseable by a `GameResponse`.
+ *
+ * @param err Some error object; should have `name`, `stack`, and `message` properties.
+ */
+const wrapApiErrorAsRegalError = (err: any): RegalError => {
+    if (!err || !err.name || !err.stack || !err.message) {
+        return new RegalError("Invalid error object.");
+    }
+
+    // If err is already a RegalError, return it
+    if (err.message.indexOf("RegalError:") !== -1) {
+        return err;
+    }
+
+    // Else, create a RegalError
+    const msg = `An error occurred while executing the request. Details: <${
+        err.name
+    }: ${err.message}>`;
+    const newErr = new RegalError(msg);
+    newErr.stack = err.stack;
+
+    return newErr;
+};
+
+/**
+ * Helper function to build a `GameResponse` based on the return values of
+ * `Game.postPlayerCommand` or `Game.postStartCommand`, including any output logs.
+ *
+ * @param err Any error that was thrown. If defined, the response will be considered failed.
+ * @param newInstance The new `GameInstance` to be returned to the client.
+ */
+const buildLogResponse = (
+    err: RegalError,
+    newInstance: GameInstance
+): GameResponse => {
+    let response: GameResponse;
+
+    if (err !== undefined) {
+        const output: GameResponseOutput = {
+            error: err,
+            wasSuccessful: false
+        };
+        response = {
+            output
+        };
+    } else {
+        const output: GameResponseOutput = {
+            log: newInstance.output.lines,
+            wasSuccessful: true
+        };
+        response = {
+            instance: newInstance,
+            output
+        };
+    }
+
+    return response;
+};
+
+const NOT_INITALIZED_ERROR_MSG =
+    "Game has not been initalized. Did you remember to call Game.init?";
+
+/**
+ * Game API
+ *
+ * Used for external interaction with the game, and shouldn't be accessed
+ * within the game itself.
+ */
+// tslint:disable-next-line:variable-name
+export const Game = {
+    get isInitialized() {
+        return this._isInitialized;
+    },
+
+    init(metadata: GameMetadata): void {
+        if (this._isInitialized) {
+            throw new RegalError("Game has already been initialized.");
+        }
+        this._isInitialized = true;
+
+        ContextManager.init();
+        MetadataManager.setMetadata(metadata);
+    },
+
+    reset(): void {
+        this._isInitialized = false;
+        ContextManager.reset();
+        HookManager.reset();
+        StaticAgentRegistry.reset();
+        MetadataManager.reset();
+    },
+
+    getMetadataCommand() {
+        let metadata: GameMetadata;
+        let err: RegalError;
+
+        try {
+            if (!this._isInitialized) {
+                throw new RegalError(NOT_INITALIZED_ERROR_MSG);
+            }
+            metadata = MetadataManager.getMetadata();
+        } catch (error) {
+            err = wrapApiErrorAsRegalError(error);
+        }
+
+        const output =
+            err !== undefined
+                ? { error: err, wasSuccessful: false }
+                : { metadata, wasSuccessful: true };
+
+        return { output };
+    },
+
+    postPlayerCommand(instance: GameInstance, command: string): GameResponse {
+        let newInstance: GameInstanceInternal;
+        let err: RegalError;
+
+        try {
+            if (!this._isInitialized) {
+                throw new RegalError(NOT_INITALIZED_ERROR_MSG);
+            }
+            const oldInstance = instance as GameInstanceInternal;
+            validateGameInstance(oldInstance);
+
+            if (command === undefined) {
+                throw new RegalError("Command must be defined.");
+            }
+            if (HookManager.playerCommandHook === undefined) {
+                throw new RegalError(
+                    "onPlayerCommand has not been implemented by the game developer."
+                );
+            }
+
+            newInstance = oldInstance.recycle();
+            newInstance.agents.scrubAgents();
+
+            const activatedEvent = HookManager.playerCommandHook(command);
+            newInstance.events.invoke(activatedEvent);
+        } catch (error) {
+            err = wrapApiErrorAsRegalError(error);
+        }
+
+        return buildLogResponse(err, newInstance);
+    },
+
+    postStartCommand(options?: Partial<GameOptions>): GameResponse {
+        let newInstance: GameInstance;
+        let err: RegalError;
+
+        try {
+            if (!this._isInitialized) {
+                throw new RegalError(NOT_INITALIZED_ERROR_MSG);
+            }
+            if (HookManager.startCommandHook === undefined) {
+                throw new RegalError(
+                    "onStartCommand has not been implemented by the game developer."
+                );
+            }
+
+            newInstance = buildGameInstance(options);
+            newInstance.events.invoke(HookManager.startCommandHook);
+        } catch (error) {
+            err = wrapApiErrorAsRegalError(error);
+        }
+
+        return buildLogResponse(err, newInstance);
+    },
+
+    postUndoCommand(instance: GameInstance): GameResponse {
+        let newInstance: GameInstanceInternal;
+        let err: RegalError;
+
+        try {
+            if (!this._isInitialized) {
+                throw new RegalError(NOT_INITALIZED_ERROR_MSG);
+            }
+            const oldInstance = instance as GameInstanceInternal;
+            validateGameInstance(oldInstance);
+
+            if (!HookManager.beforeUndoCommandHook(instance)) {
+                throw new RegalError("Undo is not allowed here.");
+            }
+
+            newInstance = oldInstance.revert();
+        } catch (error) {
+            err = wrapApiErrorAsRegalError(error);
+        }
+
+        return err !== undefined
+            ? {
+                  output: {
+                      error: err,
+                      wasSuccessful: false
+                  }
+              }
+            : {
+                  instance: newInstance,
+                  output: {
+                      wasSuccessful: true
+                  }
+              };
+    },
+
+    postOptionCommand(
+        instance: GameInstance,
+        options: Partial<GameOptions>
+    ): GameResponse {
+        let newInstance: GameInstanceInternal;
+        let err: RegalError;
+
+        try {
+            if (!this._isInitialized) {
+                throw new RegalError(NOT_INITALIZED_ERROR_MSG);
+            }
+            const oldInstance = instance as GameInstanceInternal;
+            validateGameInstance(oldInstance);
+
+            const oldOverrideKeys = Object.keys(oldInstance.options.overrides);
+            const newOptionKeys = Object.keys(options);
+
+            const newOptions: Partial<GameOptions> = {};
+
+            oldOverrideKeys
+                .filter(key => !newOptionKeys.includes(key))
+                .forEach(key => (newOptions[key] = oldInstance.options[key]));
+            newOptionKeys.forEach(key => (newOptions[key] = options[key]));
+
+            newInstance = oldInstance.recycle(newOptions);
+        } catch (error) {
+            err = wrapApiErrorAsRegalError(error);
+        }
+
+        return err !== undefined
+            ? {
+                  output: {
+                      error: err,
+                      wasSuccessful: false
+                  }
+              }
+            : {
+                  instance: newInstance,
+                  output: {
+                      wasSuccessful: true
+                  }
+              };
+    },
+
+    /** Internal variable to track whether this.init has been called. */
+    _isInitialized: false
+} as GameApiExtended;

--- a/src/api/impl/index.ts
+++ b/src/api/impl/index.ts
@@ -11,3 +11,4 @@ export {
     onBeforeUndoCommand,
     returnTrue
 } from "./api-hooks";
+export { Game } from "./game-impl";

--- a/src/api/impl/index.ts
+++ b/src/api/impl/index.ts
@@ -1,0 +1,13 @@
+/*
+ * The purpose of this file is to abstract all api-related implementations
+ * by re-exporting their constructors from a single file.
+ *
+ * Copyright (c) 2018 Joseph R Cowman
+ * Licensed under MIT License (see https://github.com/regal/regal)
+ */
+export {
+    onPlayerCommand,
+    onStartCommand,
+    onBeforeUndoCommand,
+    returnTrue
+} from "./api-hooks";

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,9 +8,5 @@
 
 export { GameResponse, GameResponseOutput } from "./game-response";
 export { Game } from "./game-api";
-export {
-    onPlayerCommand,
-    onStartCommand,
-    onBeforeUndoCommand
-} from "./api-hooks";
+export { onPlayerCommand, onStartCommand, onBeforeUndoCommand } from "./impl";
 export { HookManager } from "./api-hook-manager";

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,6 +7,12 @@
  */
 
 export { GameResponse, GameResponseOutput } from "./game-response";
-export { Game } from "./game-api";
-export { onPlayerCommand, onStartCommand, onBeforeUndoCommand } from "./impl";
+export {
+    onPlayerCommand,
+    onStartCommand,
+    onBeforeUndoCommand,
+    Game
+} from "./impl";
 export { HookManager } from "./api-hook-manager";
+export { GameApi } from "./game-api";
+export { GameApiExtended } from "./game-api-extended";

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,9 @@ export {
     GameResponseOutput,
     onPlayerCommand,
     onStartCommand,
-    onBeforeUndoCommand
+    onBeforeUndoCommand,
+    GameApi,
+    GameApiExtended
 } from "./api";
 export { GameOptions, GameMetadata, InstanceOptions } from "./config";
 export { GameInstance } from "./state";


### PR DESCRIPTION
## Description
* Split `Game` static class into two interfaces, `GameApi` and `GameApiExternal`.
* Export object called `Game`, which implements `GameApiExternal` and behaves the same as the original static class (without the import difficulties).
* Move some of the `api` component code into `api/impl`.

## Related Issues
* Resolves #92