### PR TITLE
Add gameVersion property to GameMetadata and remove readonly modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1602,7 +1602,7 @@ $ regal bundle
 Created a game bundle for 'my-first-game' at /Users/user/myDir/my-first-game.regal.js
 ```
 
-This creates a JavaScript file, which contains all of the game's dependencies (including the Game Library) and exports an implementation of [`GameApi`](#gameapi) for [playing](#playing-a-bundled-game) the game. By default, the generated bundle file will be named `my-game.regal.js`, where `my-game` is a sanitized version of the game's name, as specified in [`GameMetadata`](#gamemetadata).
+This creates a JavaScript file, which contains all the game's dependencies (including the Game Library) and exports an implementation of [`GameApi`](#gameapi) for [playing](#playing-a-bundled-game) the game. By default, the generated bundle file will be named `my-game.regal.js`, where `my-game` is a sanitized version of the game's name, as specified in [`GameMetadata`](#gamemetadata).
 
 For a list of configuration options you can use, consult the CLI's [documentation](https://github.com/regal/regal-cli/#bundle).
 
@@ -2190,14 +2190,15 @@ Metadata about the game, such as its title and author.
 
 ```ts
 interface GameMetadata {
-    readonly name: string
-    readonly author: string
-    readonly headline?: string
-    readonly description?: string
-    readonly homepage?: string
-    readonly repository?: string
-    readonly options?: Partial<GameOptions>
-    readonly regalVersion?: string
+    name: string
+    author: string
+    headline?: string
+    description?: string
+    homepage?: string
+    repository?: string
+    options?: Partial<GameOptions>
+    regalVersion?: string
+    gameVersion?: string
 }
 ```
 
@@ -2217,7 +2218,10 @@ Metadata values can be specified in the optional `regal.json` file or `regal` pr
 }
 ```
 
-If any of the metadata properties `name`, `author`, `description`, `homepage`, or `repository` aren't specified, the values of each property with the same name in `package.json` will be used. `regalVersion` should not be specified, as it is set by the library automatically. If a value is passed for `regalVersion`, an error will be thrown.
+Property Rules:
+* If any of the metadata properties `name`, `author`, `description`,  `homepage`, or `repository` aren't specified, the values of each property with the same name in `package.json` will be used.
+* `gameVersion` will be loaded from `package.json` only.
+* `regalVersion` should not be specified, as it is set by the library automatically. If a value is passed for `regalVersion`, an error will be thrown.
 
 A configuration loading tool like [**regal-bundler**](https://github.com/regal/regal-bundler) is needed if using `regal.json` or the `regal` property in `package.json`. Alternatively, metadata values can be passed explicitly via [`GameApiExtended.init()`](#init). Either way, a metadata object with at least the `name` and `author` properties specified is required before a game can receive commands.
 
@@ -2227,13 +2231,14 @@ This metadata is defined in the game's static context, meaning that it is the sa
 
 Property | Description
 --- | ---
-`readonly name: string` | The game's title.
-`readonly author: string` | The game's author.
-`readonly headline?: string` | The full description of the game.
-`readonly homepage?: string` | The URL of the project's homepage.
-`readonly repository?: string` | The URL of the project's repository.
-`readonly options?: Partial<GameOptions>` | Any options overrides for the game.
-`readonly regalVersion?: string` | The version of the Regal Game Library used by the game.
+`name: string` | The game's title.
+`author: string` | The game's author.
+`headline?: string` | The full description of the game.
+`homepage?: string` | The URL of the project's homepage.
+`repository?: string` | The URL of the project's repository.
+`options?: Partial<GameOptions>` | Any options overrides for the game.
+`regalVersion?: string` | The version of the Regal Game Library used by the game.
+`gameVersion?: string` | The game's version.
 
 ### `GameOptions`
 

--- a/src/config/game-metadata.ts
+++ b/src/config/game-metadata.ts
@@ -34,31 +34,31 @@ import { GameOptions } from "./game-options";
  */
 export interface GameMetadata {
     /** The game's title. */
-    readonly name: string;
+    name: string;
 
     /** The game's author. */
-    readonly author: string;
+    author: string;
 
     /** A brief description of the game. */
-    readonly headline?: string;
+    headline?: string;
 
     /** The full description of the game. */
-    readonly description?: string;
+    description?: string;
 
     /** The URL of the project's homepage. */
-    readonly homepage?: string;
+    homepage?: string;
 
     /** The URL of the project's repository. */
-    readonly repository?: string;
+    repository?: string;
 
     /** Any options overrides for the game. */
-    readonly options?: Partial<GameOptions>;
+    options?: Partial<GameOptions>;
 
     /** The version of the Regal Game Library used by the game. */
-    readonly regalVersion?: string;
+    regalVersion?: string;
 
     /** The game's version. */
-    readonly gameVersion?: string;
+    gameVersion?: string;
 }
 
 /** The names of every metadata property. */

--- a/src/config/game-metadata.ts
+++ b/src/config/game-metadata.ts
@@ -18,9 +18,9 @@ import { GameOptions } from "./game-options";
  * If any of the metadata properties `name`, `author`, `description`,
  * `homepage`, or `repository` aren't specified, the values of each
  * property with the same name in `package.json` will be used.
- * `regalVersion` should not be specified, as it is set by the library
- * automatically. If a value is passed for `regalVersion`,
- * an error will be thrown.
+ * `regalVersion` and `gameVersion` should not be specified, as they are
+ * set by the library automatically. If a value is passed for `regalVersion`
+ * or `gameVersion`, an error will be thrown.
  *
  * A configuration loading tool like [**regal-bundler**](https://github.com/regal/regal-bundler)
  * is needed if using `regal.json` or the `regal` property in `package.json`.
@@ -55,6 +55,9 @@ export interface GameMetadata {
 
     /** The version of the Regal Game Library used by the game. */
     readonly regalVersion?: string;
+
+    /** The game's version. */
+    readonly gameVersion?: string;
 }
 
 /** The names of every metadata property. */

--- a/src/config/game-metadata.ts
+++ b/src/config/game-metadata.ts
@@ -15,12 +15,13 @@ import { GameOptions } from "./game-options";
  * If using `regal.json`, the metadata properties should be placed in an
  * object with the key `game`.
  *
- * If any of the metadata properties `name`, `author`, `description`,
+ * Property Rules:
+ * * If any of the metadata properties `name`, `author`, `description`,
  * `homepage`, or `repository` aren't specified, the values of each
  * property with the same name in `package.json` will be used.
- * `regalVersion` and `gameVersion` should not be specified, as they are
- * set by the library automatically. If a value is passed for `regalVersion`
- * or `gameVersion`, an error will be thrown.
+ * * `gameVersion` will be loaded from `package.json` only.
+ * * `regalVersion` should not be specified, as it is set by the library automatically.
+ * If a value is passed for `regalVersion`, an error will be thrown.
  *
  * A configuration loading tool like [**regal-bundler**](https://github.com/regal/regal-bundler)
  * is needed if using `regal.json` or the `regal` property in `package.json`.
@@ -69,5 +70,6 @@ export const METADATA_KEYS = [
     "homepage",
     "repository",
     "options",
-    "regalVersion"
+    "regalVersion",
+    "gameVersion"
 ];

--- a/src/config/impl/metadata-funcs.ts
+++ b/src/config/impl/metadata-funcs.ts
@@ -36,6 +36,7 @@ const copyOptions = (opts: Partial<GameOptions>): Partial<GameOptions> => {
 export const copyMetadata = (md: GameMetadata): GameMetadata => ({
     author: md.author,
     description: md.description,
+    gameVersion: md.gameVersion,
     headline: md.headline,
     homepage: md.homepage,
     name: md.name,
@@ -48,7 +49,8 @@ const optionalStringProps: Array<keyof GameMetadata> = [
     "headline",
     "description",
     "homepage",
-    "repository"
+    "repository",
+    "gameVersion"
 ];
 
 /**

--- a/src/config/metadata-manager.ts
+++ b/src/config/metadata-manager.ts
@@ -41,7 +41,7 @@ export class MetadataManager {
         }
 
         if (!metadata.hasOwnProperty("options")) {
-            (metadata as any).options = {};
+            metadata.options = {};
         }
 
         validateMetadata(metadata);

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -15,7 +15,8 @@ export const getDemoMetadata = (): GameMetadata => ({
     description: "Game Description",
     homepage: "demogame.example",
     repository: "github.com/demogame",
-    options: {}
+    options: {},
+    gameVersion: "1.2.1"
 });
 
 export const metadataWithOptions = (opts: Partial<GameOptions>) => {
@@ -27,6 +28,7 @@ export const metadataWithOptions = (opts: Partial<GameOptions>) => {
 export const metadataWithVersion = (metadata: GameMetadata): GameMetadata => ({
     author: metadata.author,
     description: metadata.description,
+    gameVersion: metadata.gameVersion,
     headline: metadata.headline,
     homepage: metadata.homepage,
     name: metadata.name,

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -954,7 +954,7 @@ describe("Config", function() {
 
             MetadataManager.setMetadata(metadata);
 
-            (metadata as any).author = "Sneaky guy"; // Avoid readonly modifier
+            metadata.author = "Sneaky guy";
 
             expect(MetadataManager.getMetadata().author).to.equal("Joe Cowman");
         });
@@ -968,9 +968,9 @@ describe("Config", function() {
             };
 
             MetadataManager.setMetadata(metadata);
-            const retVal = MetadataManager.getMetadata() as any;
+            const retVal = MetadataManager.getMetadata();
 
-            retVal.author = "Sneaky guy"; // Avoid readonly modifier
+            retVal.author = "Sneaky guy";
 
             expect(MetadataManager.getMetadata().author).to.equal("Joe Cowman");
         });

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -975,6 +975,30 @@ describe("Config", function() {
             expect(MetadataManager.getMetadata().author).to.equal("Joe Cowman");
         });
 
+        it("Set all metadata properties successfully", function() {
+            MetadataManager.reset();
+
+            const metadata = {
+                name: "Cool Game",
+                author: "Joe Cowman",
+                headline: "The headline of my cool game.",
+                description: "The description of my cool game.",
+                homepage: "https://github.com/regal/about",
+                repository: "https://github.com/regal/regal",
+                options: {
+                    debug: true
+                },
+                gameVersion: "1.0.1"
+            };
+
+            MetadataManager.setMetadata(metadata);
+
+            expect(MetadataManager.getMetadata()).to.deep.equal({
+                ...metadata,
+                regalVersion: libraryVersion
+            });
+        });
+
         describe("Validate Metadata", function() {
             beforeEach(function() {
                 MetadataManager.reset();
@@ -1085,6 +1109,19 @@ describe("Config", function() {
                 ).to.throw(
                     RegalError,
                     "The metadata property <repository> is of type <number>, must be of type <string>."
+                );
+            });
+
+            it("gameVersion must be a string if it's defined", function() {
+                expect(() =>
+                    MetadataManager.setMetadata({
+                        name: "Cool Game",
+                        author: "Joe Cowman",
+                        gameVersion: 1
+                    } as any)
+                ).to.throw(
+                    RegalError,
+                    "The metadata property <gameVersion> is of type <number>, must be of type <string>."
                 );
             });
 


### PR DESCRIPTION
## Description
* Adds `gameVersion` property to `GameMetadata`.
* Removes `readonly` modifier from all `GameMetadata` properties.

## Checklist
### Change Type
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor (changes code but not behavior)
- [ ] Non-code Change (documentation, dependencies, etc.)

#### Is this a breaking change?
- [x] No 
- [ ] Yes

*If yes, describe what exactly this change breaks:*

### Unit Tests
- [x] Tests Added
- [x] Tests Modified
- [ ] No Change

### Documentation
- [x] In-code Docs
- [x] API Reference
- [ ] Other (*Specify:* )
- [ ] No Change

### Related Issues
Issue Number | Action | Notes
--- | --- | ---
#97 | Resolved |

### Further Action
Description | Issue Number
--- | ---
Update **regal-bundler** to load `gameVersion` from `package.json` | regal/regal-bundler#29
