### PR TITLE
Partially refactor Agent metadata

### DIFF
--- a/src/agents/agent-manager.ts
+++ b/src/agents/agent-manager.ts
@@ -20,7 +20,7 @@ import { PropertyChange } from "./agent-properties";
  */
 export interface AgentManager {
     /** The managed agent's id. */
-    id: FK<Agent>; // TODO - REMOVE
+    readonly id: FK<Agent>;
 
     /** The managed agent's metadata. */
     meta: AgentMeta;

--- a/src/agents/agent-manager.ts
+++ b/src/agents/agent-manager.ts
@@ -9,6 +9,7 @@ import { FK } from "../common";
 import { GameInstance } from "../state";
 import { Agent } from "./agent";
 import { PropertyChange } from "./agent-properties";
+import { AgentMeta } from "./agent-meta";
 
 /**
  * Manager for all data relating to a single active agent.
@@ -19,7 +20,9 @@ import { PropertyChange } from "./agent-properties";
  */
 export interface AgentManager {
     /** The managed agent's id. */
-    id: FK<Agent>;
+    id: FK<Agent>; // TODO - REMOVE
+
+    meta: AgentMeta;
 
     /** The `GameInstance` in which the agent is active. */
     game: GameInstance;

--- a/src/agents/agent-manager.ts
+++ b/src/agents/agent-manager.ts
@@ -8,8 +8,8 @@
 import { FK } from "../common";
 import { GameInstance } from "../state";
 import { Agent } from "./agent";
-import { PropertyChange } from "./agent-properties";
 import { AgentMeta } from "./agent-meta";
+import { PropertyChange } from "./agent-properties";
 
 /**
  * Manager for all data relating to a single active agent.
@@ -22,6 +22,7 @@ export interface AgentManager {
     /** The managed agent's id. */
     id: FK<Agent>; // TODO - REMOVE
 
+    /** The managed agent's metadata. */
     meta: AgentMeta;
 
     /** The `GameInstance` in which the agent is active. */

--- a/src/agents/agent-meta.ts
+++ b/src/agents/agent-meta.ts
@@ -1,0 +1,17 @@
+import { PK } from "../common";
+import { Agent } from "./agent";
+
+// tslint:disable-next-line: no-empty-interface
+export interface AgentProto {}
+
+export interface AgentMeta {
+    /** The agent's unique identifier in the context of the current game. */
+    id: PK<Agent>;
+    protoId: PK<AgentProto>;
+}
+
+export enum ReservedAgentProperty {
+    META = "meta",
+    GAME = "game",
+    TEMP_VALUES = "tempValues"
+}

--- a/src/agents/agent-meta.ts
+++ b/src/agents/agent-meta.ts
@@ -1,17 +1,35 @@
+/*
+ * Contains metadata associated with agents.
+ *
+ * Copyright (c) Joseph R Cowman
+ * Licensed under MIT License (see https://github.com/regal/regal)
+ */
+
 import { PK } from "../common";
 import { Agent } from "./agent";
 
+/** Placeholder type for classifying `PK<AgentProto>`. */
 // tslint:disable-next-line: no-empty-interface
 export interface AgentProto {}
 
+/**
+ * A special object associated with every agent which contains
+ * important metadata related to that agent. Properties in `AgentMeta`
+ * are not tracked like all other agent properties.
+ */
 export interface AgentMeta {
     /** The agent's unique identifier in the context of the current game. */
     id: PK<Agent>;
+    /** The unique identifier for the agent's prototype. */
     protoId: PK<AgentProto>;
 }
 
+/** Constants for reserved Agent properties. */
 export enum ReservedAgentProperty {
+    /** `Agent.meta` */
     META = "meta",
+    /** `AgentManager.game` */
     GAME = "game",
+    /** Used by `InactiveAgentProxy` */
     TEMP_VALUES = "tempValues"
 }

--- a/src/agents/agent.ts
+++ b/src/agents/agent.ts
@@ -9,12 +9,13 @@
  * Licensed under MIT License (see https://github.com/regal/regal)
  */
 
-import { PK } from "../common";
+import { AgentMeta } from "./agent-meta";
 import { buildInactiveAgentProxy } from "./impl";
+import { defaultAgentMeta } from "./impl/agent-meta-transformers";
 
 /** Determines whether an object is an `Agent`. */
 export const isAgent = (o: any): o is Agent =>
-    o !== undefined && (o as Agent).id !== undefined;
+    o !== undefined && (o as Agent).meta !== undefined;
 
 /**
  * A game object, or *agent*, is a JavaScript object that contains Regal game state.
@@ -26,8 +27,7 @@ export const isAgent = (o: any): o is Agent =>
  * a `RegalError` will be thrown.
  */
 export class Agent {
-    /** The agent's unique identifier in the context of the current game. */
-    public readonly id: PK<Agent>;
+    public meta: AgentMeta;
 
     /**
      * Constructs a new `Agent`. This constructor should almost never be called
@@ -38,6 +38,7 @@ export class Agent {
      * for all game instances.
      */
     constructor() {
+        this.meta = defaultAgentMeta();
         return buildInactiveAgentProxy(this);
     }
 }

--- a/src/agents/impl/activate-agent.ts
+++ b/src/agents/impl/activate-agent.ts
@@ -13,6 +13,7 @@ import {
     buildActiveAgentArrayProxy,
     buildActiveAgentProxy
 } from "./active-agent-proxy";
+import { activateAgentMeta } from "./agent-meta-transformers";
 import { isAgentActive, propertyIsAgentId } from "./agent-utils";
 
 /**
@@ -28,11 +29,8 @@ export const activateAgent = <T extends Agent>(
     game: GameInstanceInternal,
     agent: T
 ): T => {
-    let id = agent.id;
-
-    if (id === undefined || !isAgentActive(id)) {
-        id = game.agents.reserveNewId();
-        (agent as Mutable<Agent>).id = id;
+    if (!isAgentActive(agent.meta.id)) {
+        agent.meta = activateAgentMeta(game.agents.reserveNewId())(agent.meta);
     }
 
     let activeAgent: T;
@@ -48,9 +46,9 @@ export const activateAgent = <T extends Agent>(
             .filter(propertyIsAgentId)
             .forEach(key => (tempValues[key] = agent[key]));
 
-        activeAgent = buildActiveAgentArrayProxy(id, game) as T;
+        activeAgent = buildActiveAgentArrayProxy(agent.meta.id, game) as T;
     } else {
-        activeAgent = buildActiveAgentProxy(id, game) as T;
+        activeAgent = buildActiveAgentProxy(agent.meta.id, game) as T;
     }
 
     for (const prop of Object.keys(tempValues)) {

--- a/src/agents/impl/activate-agent.ts
+++ b/src/agents/impl/activate-agent.ts
@@ -29,7 +29,7 @@ export const activateAgent = <T extends Agent>(
     game: GameInstanceInternal,
     agent: T
 ): T => {
-    if (!isAgentActive(agent.meta.id)) {
+    if (agent.meta === undefined || !isAgentActive(agent.meta.id)) {
         agent.meta = activateAgentMeta(game.agents.reserveNewId())(agent.meta);
     }
 

--- a/src/agents/impl/activate-agent.ts
+++ b/src/agents/impl/activate-agent.ts
@@ -13,7 +13,7 @@ import {
     buildActiveAgentArrayProxy,
     buildActiveAgentProxy
 } from "./active-agent-proxy";
-import { activateAgentMeta } from "./agent-meta-transformers";
+import { agentMetaWithID } from "./agent-meta-transformers";
 import { isAgentActive, propertyIsAgentId } from "./agent-utils";
 
 /**
@@ -30,7 +30,7 @@ export const activateAgent = <T extends Agent>(
     agent: T
 ): T => {
     if (agent.meta === undefined || !isAgentActive(agent.meta.id)) {
-        agent.meta = activateAgentMeta(game.agents.reserveNewId())(agent.meta);
+        agent.meta = agentMetaWithID(game.agents.reserveNewId())(agent.meta);
     }
 
     let activeAgent: T;

--- a/src/agents/impl/active-agent-proxy.ts
+++ b/src/agents/impl/active-agent-proxy.ts
@@ -8,6 +8,7 @@
 import { PK } from "../../common";
 import { GameInstanceInternal } from "../../state";
 import { Agent } from "../agent";
+import { ReservedAgentProperty } from "../agent-meta";
 
 /** Builds the proxy handler for an active agent proxy. */
 const activeAgentProxyHandler = (

--- a/src/agents/impl/agent-manager-impl.ts
+++ b/src/agents/impl/agent-manager-impl.ts
@@ -30,18 +30,14 @@ export const buildAgentManager = (
 
 /** Implementation of `AgentManager`. */
 class AgentManagerImpl implements AgentManager {
-    private _meta: AgentMeta;
+    public meta: AgentMeta;
 
     constructor(id: FK<Agent>, public game: GameInstanceInternal) {
-        this._meta = activateAgentMeta(id)(defaultAgentMeta());
-    }
-
-    public get meta(): AgentMeta {
-        return this._meta;
+        this.meta = activateAgentMeta(id)(defaultAgentMeta());
     }
 
     public get id(): FK<Agent> {
-        return this._meta.id;
+        return this.meta.id;
     }
 
     public hasPropertyRecord(property: PropertyKey): boolean {

--- a/src/agents/impl/agent-manager-impl.ts
+++ b/src/agents/impl/agent-manager-impl.ts
@@ -20,7 +20,7 @@ import {
 } from "../agent-properties";
 import { isAgentReference } from "../agent-reference";
 import { StaticAgentRegistry } from "../static-agent-registry";
-import { activateAgentMeta, defaultAgentMeta } from "./agent-meta-transformers";
+import { agentMetaWithID, defaultAgentMeta } from "./agent-meta-transformers";
 
 /** Builds an implementation of `AgentManager` for the given `Agent` id and `GameInstance`. */
 export const buildAgentManager = (
@@ -33,7 +33,7 @@ class AgentManagerImpl implements AgentManager {
     public meta: AgentMeta;
 
     constructor(id: FK<Agent>, public game: GameInstanceInternal) {
-        this.meta = activateAgentMeta(id)(defaultAgentMeta());
+        this.meta = agentMetaWithID(id)(defaultAgentMeta());
     }
 
     public get id(): FK<Agent> {

--- a/src/agents/impl/agent-manager-impl.ts
+++ b/src/agents/impl/agent-manager-impl.ts
@@ -20,6 +20,7 @@ import {
 } from "../agent-properties";
 import { isAgentReference } from "../agent-reference";
 import { StaticAgentRegistry } from "../static-agent-registry";
+import { activateAgentMeta, defaultAgentMeta } from "./agent-meta-transformers";
 
 /** Builds an implementation of `AgentManager` for the given `Agent` id and `GameInstance`. */
 export const buildAgentManager = (
@@ -29,10 +30,18 @@ export const buildAgentManager = (
 
 /** Implementation of `AgentManager`. */
 class AgentManagerImpl implements AgentManager {
-    constructor(public id: FK<Agent>, public game: GameInstanceInternal) {}
+    private _meta: AgentMeta;
+
+    constructor(id: FK<Agent>, public game: GameInstanceInternal) {
+        this._meta = activateAgentMeta(id)(defaultAgentMeta());
+    }
 
     public get meta(): AgentMeta {
-        throw new Error("you tried to get meta"); // TODO - need to set meta somewhere
+        return this._meta;
+    }
+
+    public get id(): FK<Agent> {
+        return this._meta.id;
     }
 
     public hasPropertyRecord(property: PropertyKey): boolean {

--- a/src/agents/impl/agent-manager-impl.ts
+++ b/src/agents/impl/agent-manager-impl.ts
@@ -11,6 +11,7 @@ import { EventRecord, getUntrackedEventPK } from "../../events";
 import { GameInstanceInternal } from "../../state";
 import { Agent } from "../agent";
 import { AgentManager } from "../agent-manager";
+import { AgentMeta, ReservedAgentProperty } from "../agent-meta";
 import {
     pcForAgentManager,
     pcForEventRecord,
@@ -29,6 +30,10 @@ export const buildAgentManager = (
 /** Implementation of `AgentManager`. */
 class AgentManagerImpl implements AgentManager {
     constructor(public id: FK<Agent>, public game: GameInstanceInternal) {}
+
+    public get meta(): AgentMeta {
+        throw new Error("you tried to get meta"); // TODO - need to set meta somewhere
+    }
 
     public hasPropertyRecord(property: PropertyKey): boolean {
         if (property === "constructor") {

--- a/src/agents/impl/agent-meta-transformers.ts
+++ b/src/agents/impl/agent-meta-transformers.ts
@@ -13,15 +13,15 @@ export const defaultAgentMeta = (): AgentMeta => ({
     protoId: undefined
 });
 
-export const initStaticAgentMeta = transformMeta(() => ({
+export const staticAgentMeta = transformMeta(() => ({
     id: STATIC_AGENT_PK_PROVIDER.next()
 }));
 
-export const initInactiveAgentMeta = transformMeta(() => ({
+export const inactiveAgentMeta = transformMeta(() => ({
     id: getInactiveAgentPK()
 }));
 
-export const activateAgentMeta = (id: PK<Agent>) =>
+export const agentMetaWithID = (id: PK<Agent>) =>
     transformMeta(() => ({
         id
     }));

--- a/src/agents/impl/agent-meta-transformers.ts
+++ b/src/agents/impl/agent-meta-transformers.ts
@@ -1,0 +1,27 @@
+import { PK } from "../../common";
+import { Agent } from "../agent";
+import { AgentMeta } from "../agent-meta";
+import { STATIC_AGENT_PK_PROVIDER } from "./agent-keys";
+import { getInactiveAgentPK } from "./agent-utils";
+
+const transformMeta = (
+    transformer: (meta?: AgentMeta) => Partial<AgentMeta>
+) => (oldMeta: AgentMeta) => ({ ...oldMeta, ...transformer(oldMeta) });
+
+export const defaultAgentMeta = (): AgentMeta => ({
+    id: undefined,
+    protoId: undefined
+});
+
+export const initStaticAgentMeta = transformMeta(() => ({
+    id: STATIC_AGENT_PK_PROVIDER.next()
+}));
+
+export const initInactiveAgentMeta = transformMeta(() => ({
+    id: getInactiveAgentPK()
+}));
+
+export const activateAgentMeta = (id: PK<Agent>) =>
+    transformMeta(() => ({
+        id
+    }));

--- a/src/agents/impl/agent-meta-transformers.ts
+++ b/src/agents/impl/agent-meta-transformers.ts
@@ -1,26 +1,49 @@
 import { PK } from "../../common";
 import { Agent } from "../agent";
 import { AgentMeta } from "../agent-meta";
+/*
+ * Functional transformers for `AgentMeta` objects.
+ *
+ * Copyright (c) Joseph R Cowman
+ * Licensed under MIT License (see https://github.com/regal/regal)
+ */
+
 import { STATIC_AGENT_PK_PROVIDER } from "./agent-keys";
 import { getInactiveAgentPK } from "./agent-utils";
 
+/**
+ * Utility that builds an `AgentMeta` transformer.
+ * @param transformFn Function that returns a new `AgentMeta`, optionally
+ * using the previous `AgentMeta`.
+ */
 const transformMeta = (
-    transformer: (meta?: AgentMeta) => Partial<AgentMeta>
-) => (oldMeta: AgentMeta) => ({ ...oldMeta, ...transformer(oldMeta) });
+    transformFn: (meta?: AgentMeta) => Partial<AgentMeta>
+) => (oldMeta: AgentMeta) => ({ ...oldMeta, ...transformFn(oldMeta) });
 
+/** Returns an `AgentMeta` with its default values. */
 export const defaultAgentMeta = (): AgentMeta => ({
     id: undefined,
     protoId: undefined
 });
 
+/**
+ * Returns an `AgentMeta` with its id set to the next static agent PK.
+ */
 export const staticAgentMeta = transformMeta(() => ({
     id: STATIC_AGENT_PK_PROVIDER.next()
 }));
 
+/**
+ * Returns an `AgentMeta` with its id set to the reserved inactive agent PK.
+ */
 export const inactiveAgentMeta = transformMeta(() => ({
     id: getInactiveAgentPK()
 }));
 
+/**
+ * Returns an `AgentMeta` transformer that transforms an `AgentMeta` id
+ * into the given id.
+ */
 export const agentMetaWithID = (id: PK<Agent>) =>
     transformMeta(() => ({
         id

--- a/src/agents/impl/inactive-agent-proxy.ts
+++ b/src/agents/impl/inactive-agent-proxy.ts
@@ -5,12 +5,13 @@
  * Licensed under MIT License (see https://github.com/regal/regal)
  */
 
-import { Mutable } from "../../common";
 import { RegalError } from "../../error";
 import { ContextManager } from "../../state";
 import { Agent } from "../agent";
+import { ReservedAgentProperty } from "../agent-meta";
 import { StaticAgentRegistry } from "../static-agent-registry";
-import { getInactiveAgentPK, isAgentActive } from "./agent-utils";
+import { initInactiveAgentMeta } from "./agent-meta-transformers";
+import { isAgentActive } from "./agent-utils";
 
 /**
  * Builds a proxy for an inactive agent. Before an agent is activated
@@ -29,11 +30,11 @@ import { getInactiveAgentPK, isAgentActive } from "./agent-utils";
  * @param agent The agent to be proxied.
  * @returns The inactive agent proxy.
  */
-export const buildInactiveAgentProxy = (agent: Mutable<Agent>): Agent => {
+export const buildInactiveAgentProxy = (agent: Agent): Agent => {
     if (ContextManager.isContextStatic()) {
         StaticAgentRegistry.addAgent(agent);
     } else {
-        agent.id = getInactiveAgentPK();
+        agent.meta = initInactiveAgentMeta(agent.meta);
     }
 
     return new Proxy(agent, {
@@ -41,13 +42,13 @@ export const buildInactiveAgentProxy = (agent: Mutable<Agent>): Agent => {
         tempValues: {},
 
         get(target: Agent, property: PropertyKey) {
-            if (property === "tempValues") {
+            if (property === ReservedAgentProperty.TEMP_VALUES) {
                 return this.tempValues;
             }
 
             if (
-                property !== "id" &&
-                property !== "refId" &&
+                property !== ReservedAgentProperty.META &&
+                property !== "refId" && // TODO - Remove refId
                 !ContextManager.isContextStatic()
             ) {
                 throw new RegalError(
@@ -59,18 +60,24 @@ export const buildInactiveAgentProxy = (agent: Mutable<Agent>): Agent => {
         },
 
         set(target: Agent, property: PropertyKey, value: any) {
-            if (property === "id" && !isAgentActive(target.id)) {
+            if (
+                property === ReservedAgentProperty.META &&
+                !isAgentActive(target.meta.id)
+            ) {
                 return Reflect.set(target, property, value);
             }
 
             if (ContextManager.isContextStatic()) {
                 // When adding an array as a property of a static agent, we need to
                 // treat that array like an agent and register a static id for it
-                if (value instanceof Array && (value as any).id === undefined) {
+                if (
+                    value instanceof Array &&
+                    (value as any).meta.id === undefined
+                ) {
                     StaticAgentRegistry.addAgent(value as any);
                 }
                 return Reflect.set(target, property, value);
-            } else if (StaticAgentRegistry.hasAgent(target.id)) {
+            } else if (StaticAgentRegistry.hasAgent(target.meta.id)) {
                 throw new RegalError(
                     "This static agent must be activated before it may be modified."
                 );

--- a/src/agents/impl/inactive-agent-proxy.ts
+++ b/src/agents/impl/inactive-agent-proxy.ts
@@ -10,10 +10,7 @@ import { ContextManager } from "../../state";
 import { Agent } from "../agent";
 import { ReservedAgentProperty } from "../agent-meta";
 import { StaticAgentRegistry } from "../static-agent-registry";
-import {
-    defaultAgentMeta,
-    initInactiveAgentMeta
-} from "./agent-meta-transformers";
+import { defaultAgentMeta, inactiveAgentMeta } from "./agent-meta-transformers";
 import { isAgentActive } from "./agent-utils";
 
 /**
@@ -37,7 +34,7 @@ export const buildInactiveAgentProxy = (agent: Agent): Agent => {
     if (ContextManager.isContextStatic()) {
         StaticAgentRegistry.addAgent(agent);
     } else {
-        agent.meta = initInactiveAgentMeta(agent.meta);
+        agent.meta = inactiveAgentMeta(agent.meta);
     }
 
     return new Proxy(agent, {

--- a/src/agents/impl/inactive-agent-proxy.ts
+++ b/src/agents/impl/inactive-agent-proxy.ts
@@ -10,7 +10,10 @@ import { ContextManager } from "../../state";
 import { Agent } from "../agent";
 import { ReservedAgentProperty } from "../agent-meta";
 import { StaticAgentRegistry } from "../static-agent-registry";
-import { initInactiveAgentMeta } from "./agent-meta-transformers";
+import {
+    defaultAgentMeta,
+    initInactiveAgentMeta
+} from "./agent-meta-transformers";
 import { isAgentActive } from "./agent-utils";
 
 /**
@@ -72,8 +75,9 @@ export const buildInactiveAgentProxy = (agent: Agent): Agent => {
                 // treat that array like an agent and register a static id for it
                 if (
                     value instanceof Array &&
-                    (value as any).meta.id === undefined
+                    (value as any).meta === undefined
                 ) {
+                    (value as any).meta = defaultAgentMeta();
                     StaticAgentRegistry.addAgent(value as any);
                 }
                 return Reflect.set(target, property, value);

--- a/src/agents/impl/instance-agents-impl.ts
+++ b/src/agents/impl/instance-agents-impl.ts
@@ -24,7 +24,7 @@ import {
 } from "./active-agent-proxy";
 import { STATIC_AGENT_PK_PROVIDER } from "./agent-keys";
 import { buildAgentManager } from "./agent-manager-impl";
-import { activateAgentMeta } from "./agent-meta-transformers";
+import { agentMetaWithID } from "./agent-meta-transformers";
 import {
     getGameInstancePK,
     isAgentActive,
@@ -162,7 +162,7 @@ class InstanceAgentsImpl implements InstanceAgentsInternal {
 
         if (isAgent(value)) {
             if (!isAgentActive(value.meta.id)) {
-                value.meta = activateAgentMeta(this.reserveNewId())(value.meta);
+                value.meta = agentMetaWithID(this.reserveNewId())(value.meta);
                 value = this.game.using(value);
             }
             value =
@@ -170,7 +170,7 @@ class InstanceAgentsImpl implements InstanceAgentsInternal {
                     ? new AgentArrayReference((value as any).meta.id)
                     : new AgentReference(value.meta.id);
         } else if (value instanceof Array) {
-            (value as any).meta = activateAgentMeta(this.reserveNewId())(
+            (value as any).meta = agentMetaWithID(this.reserveNewId())(
                 {} as any // TODO - make meta for array
             );
             value = this.game.using(value);

--- a/src/agents/impl/instance-agents-impl.ts
+++ b/src/agents/impl/instance-agents-impl.ts
@@ -14,6 +14,7 @@ import {
     isAgentArrayReference
 } from "../agent-array-reference";
 import { AgentManager, isAgentManager } from "../agent-manager";
+import { ReservedAgentProperty } from "../agent-meta";
 import { AgentReference, isAgentReference } from "../agent-reference";
 import { InstanceAgentsInternal } from "../instance-agents-internal";
 import { StaticAgentRegistry } from "../static-agent-registry";
@@ -23,13 +24,12 @@ import {
 } from "./active-agent-proxy";
 import { STATIC_AGENT_PK_PROVIDER } from "./agent-keys";
 import { buildAgentManager } from "./agent-manager-impl";
+import { activateAgentMeta } from "./agent-meta-transformers";
 import {
     getGameInstancePK,
     isAgentActive,
     propertyIsAgentId
 } from "./agent-utils";
-import { activateAgentMeta } from "./agent-meta-transformers";
-import { ReservedAgentProperty } from "../agent-meta";
 
 /**
  * Builds an implementation of `InstanceAgentsInternal` for the given `GameInstance`

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -15,3 +15,4 @@ export {
     activateAgent,
     getGameInstancePK
 } from "./impl";
+export { AgentMeta, AgentProto } from "./agent-meta";

--- a/src/agents/static-agent-registry.ts
+++ b/src/agents/static-agent-registry.ts
@@ -16,6 +16,8 @@ import {
     propertyIsAgentId,
     STATIC_AGENT_PK_PROVIDER
 } from "./impl";
+import { initStaticAgentMeta } from "./impl/agent-meta-transformers";
+import { isAgentActive } from "./impl/agent-utils";
 
 /**
  * Static class that manages all static agents used in the game.
@@ -61,15 +63,18 @@ export class StaticAgentRegistry {
      * Adds an agent to the registry, setting its id to the next available primary key.
      * @param agent The agent to be added.
      */
-    public static addAgent(agent: Mutable<Agent>): void {
-        if (agent.id !== undefined && !agent.id.equals(getInactiveAgentPK())) {
+    public static addAgent(agent: Agent): void {
+        const currentId = agent.meta.id;
+
+        if (currentId !== undefined && !isAgentActive(currentId)) {
             throw new RegalError(
-                `Only inactive agents can be added to the static registry. This one already has an id of <${agent.id.value()}>.`
+                `Only inactive agents can be added to the static registry. This one already has an id of <${currentId.value()}>.`
             );
         }
-        agent.id = STATIC_AGENT_PK_PROVIDER.next();
 
-        this[agent.id.value()] = agent;
+        agent.meta = initStaticAgentMeta(agent.meta);
+
+        this[agent.meta.id.value()] = agent;
     }
 
     /** Removes all agents from the registry and resets the static PK provider. */

--- a/src/agents/static-agent-registry.ts
+++ b/src/agents/static-agent-registry.ts
@@ -66,7 +66,7 @@ export class StaticAgentRegistry {
     public static addAgent(agent: Agent): void {
         const currentId = agent.meta.id;
 
-        if (currentId !== undefined && !isAgentActive(currentId)) {
+        if (currentId !== undefined && isAgentActive(currentId)) {
             throw new RegalError(
                 `Only inactive agents can be added to the static registry. This one already has an id of <${currentId.value()}>.`
             );

--- a/src/agents/static-agent-registry.ts
+++ b/src/agents/static-agent-registry.ts
@@ -16,7 +16,7 @@ import {
     propertyIsAgentId,
     STATIC_AGENT_PK_PROVIDER
 } from "./impl";
-import { initStaticAgentMeta } from "./impl/agent-meta-transformers";
+import { staticAgentMeta } from "./impl/agent-meta-transformers";
 import { isAgentActive } from "./impl/agent-utils";
 
 /**
@@ -72,7 +72,7 @@ export class StaticAgentRegistry {
             );
         }
 
-        agent.meta = initStaticAgentMeta(agent.meta);
+        agent.meta = staticAgentMeta(agent.meta);
 
         this[agent.meta.id.value()] = agent;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@
  * Licensed under MIT License (see https://github.com/regal/regal)
  */
 
-export { Agent } from "./agents";
+export { Agent, AgentMeta, AgentProto } from "./agents";
 export { RegalError } from "./error";
 export {
     EventFunction,

--- a/src/state/impl/game-instance-impl.ts
+++ b/src/state/impl/game-instance-impl.ts
@@ -15,6 +15,7 @@ import {
     StaticAgentRegistry
 } from "../../agents";
 import { isAgentArrayReference } from "../../agents/agent-array-reference";
+import { ReservedAgentProperty } from "../../agents/agent-meta";
 import { isAgentReference } from "../../agents/agent-reference";
 import { buildPKProvider, FK } from "../../common";
 import {
@@ -235,7 +236,9 @@ class GameInstanceImpl<StateType = any>
                 const id = am.id;
 
                 const props = Object.keys(am).filter(
-                    key => key !== "game" && key !== "id"
+                    key =>
+                        key !== ReservedAgentProperty.GAME &&
+                        key !== ReservedAgentProperty.META
                 );
 
                 for (const prop of props) {

--- a/src/state/impl/game-instance-impl.ts
+++ b/src/state/impl/game-instance-impl.ts
@@ -264,12 +264,12 @@ class GameInstanceImpl<StateType = any>
                             const areEqAgents =
                                 isAgentReference(targetVal) &&
                                 isAgent(currentVal) &&
-                                targetVal.refId === currentVal.id;
+                                targetVal.refId === currentVal.meta.id;
 
                             const areEqAgentArrs =
                                 isAgentArrayReference(targetVal) &&
                                 isAgent(currentVal) &&
-                                targetVal.arRefId === currentVal.id;
+                                targetVal.arRefId === currentVal.meta.id;
 
                             if (!areEqAgents && !areEqAgentArrs) {
                                 target.setAgentProperty(id, prop, targetVal);

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -6,6 +6,7 @@ import { buildPKProvider, PK } from "../src/common";
 import { OutputLine } from "../src/output";
 import { getUntrackedEventPK } from "../src/events";
 import { RandomRecord } from "../src/random";
+import { AgentMeta } from "../src/agents/agent-meta";
 
 // log had to be moved to its own file to eliminate circular dependencies
 // when used to debug src
@@ -62,8 +63,22 @@ export const makeAgents = (startFrom: number, amount: number) => {
 };
 
 export enum TestProperty {
-    REQUIRE_BUT_SKIP
+    REQUIRE_BUT_SKIP,
+    SMART_OBJECT
 }
+
+export interface SmartObject {
+    prop: TestProperty;
+    object: object;
+}
+
+export const smartObj = (obj: object): SmartObject => ({
+    prop: TestProperty.SMART_OBJECT,
+    object: obj
+});
+
+export const isSmartObject = (obj: any): obj is SmartObject =>
+    obj !== undefined && obj.prop !== undefined;
 
 export const smartObjectEquals = (actual: object, expected: object) => {
     // Test property key match
@@ -72,9 +87,13 @@ export const smartObjectEquals = (actual: object, expected: object) => {
     expect(actualKeys).to.deep.equal(expectedKeys);
 
     for (const prop in expected) {
+        const actualVal = actual[prop];
         const expectedVal = expected[prop];
-        if (expectedVal !== TestProperty.REQUIRE_BUT_SKIP) {
-            expect(actual[prop]).to.deep.equal(expectedVal);
+
+        if (isSmartObject(expectedVal)) {
+            smartObjectEquals(actualVal, expectedVal.object);
+        } else if (expectedVal !== TestProperty.REQUIRE_BUT_SKIP) {
+            expect(actualVal).to.deep.equal(expectedVal);
         }
     }
 };
@@ -108,3 +127,11 @@ export const ePKAtNum = (index: number) => getUntrackedEventPK().plus(index);
 // RandomRecord PKs
 export const rPKs = (additional: number) =>
     pks(additional, getInitialRandomPK());
+
+export const testMeta = (id: PK<Agent>) => {
+    const meta = {
+        id,
+        protoId: TestProperty.REQUIRE_BUT_SKIP
+    };
+    return smartObj(meta);
+};

--- a/test/unit/agents.test.ts
+++ b/test/unit/agents.test.ts
@@ -206,10 +206,7 @@ describe("Agents", function() {
             Game.init(MD);
 
             const myGame = buildGameInstance();
-            // const parent = myGame.using(new Parent(new Dummy("D1", 10)));
-            const child = new Dummy("D1", 10);
-            let parent = new Parent(child);
-            parent = myGame.using(parent);
+            const parent = myGame.using(new Parent(new Dummy("D1", 10)));
             expect(parent.child.name).to.equal("D1");
             expect(parent.child.health).to.equal(10);
         });

--- a/test/unit/agents.test.ts
+++ b/test/unit/agents.test.ts
@@ -9,7 +9,9 @@ import {
     smartObjectEquals,
     TestProperty,
     aPKs,
-    ePKs
+    ePKs,
+    testMeta,
+    smartObj
 } from "../test-utils";
 import { Game } from "../../src/api";
 import {
@@ -549,8 +551,8 @@ describe("Agents", function() {
                 smartObjectEquals(myGame.agents, {
                     _pkProvider: TestProperty.REQUIRE_BUT_SKIP,
                     game: myGame,
-                    [pk0.value()]: {
-                        id: pk0,
+                    [pk0.value()]: smartObj({
+                        meta: testMeta(pk0),
                         game: myGame,
                         arr: [
                             {
@@ -561,9 +563,9 @@ describe("Agents", function() {
                                 final: { arRefId: pk1 }
                             }
                         ]
-                    },
-                    [pk1.value()]: {
-                        id: pk1,
+                    }),
+                    [pk1.value()]: smartObj({
+                        meta: testMeta(pk1),
                         game: myGame,
                         length: [
                             {
@@ -574,7 +576,7 @@ describe("Agents", function() {
                                 final: 0
                             }
                         ]
-                    }
+                    })
                 });
                 expect(myGame.events.history).to.deep.equal([
                     {
@@ -625,8 +627,8 @@ describe("Agents", function() {
                 smartObjectEquals(myGame.agents, {
                     _pkProvider: TestProperty.REQUIRE_BUT_SKIP,
                     game: myGame,
-                    [pk0.value()]: {
-                        id: pk0,
+                    [pk0.value()]: smartObj({
+                        meta: testMeta(pk0),
                         game: myGame,
                         arr: [
                             {
@@ -637,9 +639,9 @@ describe("Agents", function() {
                                 final: { arRefId: pk1 }
                             }
                         ]
-                    },
-                    [pk1.value()]: {
-                        id: pk1,
+                    }),
+                    [pk1.value()]: smartObj({
+                        meta: testMeta(pk1),
                         game: myGame,
                         length: [
                             {
@@ -677,7 +679,7 @@ describe("Agents", function() {
                                 final: "foo"
                             }
                         ]
-                    }
+                    })
                 });
                 expect(myGame.events.history).to.deep.equal([
                     {
@@ -759,8 +761,8 @@ describe("Agents", function() {
                 smartObjectEquals(myGame.agents, {
                     _pkProvider: TestProperty.REQUIRE_BUT_SKIP,
                     game: myGame,
-                    [pk0.value()]: {
-                        id: pk0,
+                    [pk0.value()]: smartObj({
+                        meta: testMeta(pk0),
                         game: myGame,
                         arr: [
                             {
@@ -771,9 +773,9 @@ describe("Agents", function() {
                                 final: { arRefId: pk4 }
                             }
                         ]
-                    },
-                    [pk1.value()]: {
-                        id: pk1,
+                    }),
+                    [pk1.value()]: smartObj({
+                        meta: testMeta(pk1),
                         game: myGame,
                         name: [
                             {
@@ -793,9 +795,9 @@ describe("Agents", function() {
                                 final: 5
                             }
                         ]
-                    },
-                    [pk2.value()]: {
-                        id: pk2,
+                    }),
+                    [pk2.value()]: smartObj({
+                        meta: testMeta(pk2),
                         game: myGame,
                         name: [
                             {
@@ -815,9 +817,9 @@ describe("Agents", function() {
                                 final: 10
                             }
                         ]
-                    },
-                    [pk3.value()]: {
-                        id: pk3,
+                    }),
+                    [pk3.value()]: smartObj({
+                        meta: testMeta(pk3),
                         game: myGame,
                         name: [
                             {
@@ -837,9 +839,9 @@ describe("Agents", function() {
                                 final: 15
                             }
                         ]
-                    },
-                    [pk4.value()]: {
-                        id: pk4,
+                    }),
+                    [pk4.value()]: smartObj({
+                        meta: testMeta(pk4),
                         game: myGame,
                         length: [
                             {
@@ -877,7 +879,7 @@ describe("Agents", function() {
                                 final: { refId: pk3 }
                             }
                         ]
-                    }
+                    })
                 });
                 expect(myGame.events.history).to.deep.equal([
                     {
@@ -965,8 +967,8 @@ describe("Agents", function() {
                     myGame.using(d1)
                 );
                 expect(myGame.state.dummy.dummies[1].name).to.equal("D2");
-                expect(myGame.state.dummy.dummies[1].dummies[0]).to.deep.equal({
-                    id: getGameInstancePK().plus(1),
+                smartObjectEquals(myGame.state.dummy.dummies[1].dummies[0], {
+                    meta: testMeta(getGameInstancePK().plus(1)),
                     name: "D1",
                     health: 10
                 });
@@ -985,10 +987,13 @@ describe("Agents", function() {
 
                 const [_pk0, pk1, pk2] = aPKs(2);
 
-                expect(myGame.state.dummies).to.deep.equal([
-                    { id: pk1, name: "D1", health: 10 },
-                    { id: pk2, name: "D2", health: 15 }
-                ]);
+                const expectedVal = [
+                    smartObj({ meta: testMeta(pk1), name: "D1", health: 10 }),
+                    smartObj({ meta: testMeta(pk2), name: "D2", health: 15 })
+                ];
+                (expectedVal as any).meta = TestProperty.REQUIRE_BUT_SKIP;
+
+                smartObjectEquals(myGame.state.dummies, expectedVal);
             });
 
             it("Array.prototype.unshift is functional on agent arrays", function() {
@@ -1033,25 +1038,28 @@ describe("Agents", function() {
                 const pk2 = getGameInstancePK().plus(2);
                 const pk4 = pk2.plus(2);
 
-                expect(myGame.state.allVals).to.deep.equal([
-                    true,
-                    {
-                        id: pk2,
-                        name: "D1",
-                        health: 10
-                    },
-                    "hello",
-                    {
-                        id: pk4,
-                        name: "D2",
-                        health: 15
-                    },
-                    {
-                        id: pk2,
-                        name: "D1",
-                        health: 10
-                    }
-                ]);
+                smartObjectEquals(
+                    [...myGame.state.allVals],
+                    [
+                        true,
+                        smartObj({
+                            meta: testMeta(pk2),
+                            name: "D1",
+                            health: 10
+                        }),
+                        "hello",
+                        smartObj({
+                            meta: testMeta(pk4),
+                            name: "D2",
+                            health: 15
+                        }),
+                        smartObj({
+                            meta: testMeta(pk2),
+                            name: "D1",
+                            health: 10
+                        })
+                    ]
+                );
             });
 
             it("Length property of agent arrays is functional", function() {
@@ -1081,13 +1089,16 @@ describe("Agents", function() {
                     game.state.arr = arr;
                 })(myGame);
 
-                expect(myGame.state.arr).to.deep.equal([
-                    {
-                        id: getGameInstancePK().plus(2),
-                        health: 30,
-                        foo: true
-                    }
-                ]);
+                smartObjectEquals(
+                    [...myGame.state.arr],
+                    [
+                        smartObj({
+                            meta: testMeta(getGameInstancePK().plus(2)),
+                            health: 30,
+                            foo: true
+                        })
+                    ]
+                );
             });
 
             it("Multi-dimensional agent arrays are functional", function() {
@@ -1098,43 +1109,48 @@ describe("Agents", function() {
 
                 const [_pk0, pk1, pk2, pk3, pk4, pk5, pk6, pk7, pk8] = aPKs(8);
 
-                expect(arr).to.deep.equal([
-                    [
-                        {
-                            id: pk3,
-                            name: "D10",
-                            health: 10
-                        },
-                        {
-                            id: pk4,
-                            name: "D11",
-                            health: 11
-                        },
-                        {
-                            id: pk5,
-                            name: "D12",
-                            health: 12
-                        },
-                        {
-                            id: pk6,
-                            name: "D13",
-                            health: 13
-                        },
-                        {
-                            id: pk7,
-                            name: "D14",
-                            health: 14
-                        }
-                    ]
-                ]);
+                const expectedInnerArray = [
+                    smartObj({
+                        meta: testMeta(pk3),
+                        name: "D10",
+                        health: 10
+                    }),
+                    smartObj({
+                        meta: testMeta(pk4),
+                        name: "D11",
+                        health: 11
+                    }),
+                    smartObj({
+                        meta: testMeta(pk5),
+                        name: "D12",
+                        health: 12
+                    }),
+                    smartObj({
+                        meta: testMeta(pk6),
+                        name: "D13",
+                        health: 13
+                    }),
+                    smartObj({
+                        meta: testMeta(pk7),
+                        name: "D14",
+                        health: 14
+                    })
+                ] as any;
+                expectedInnerArray.meta = testMeta(pk2);
+                const expectedOuterArray = [
+                    smartObj(expectedInnerArray)
+                ] as any;
+                expectedOuterArray.meta = testMeta(pk1);
+
+                smartObjectEquals(arr, expectedOuterArray);
                 expect(arr.length).to.equal(1);
                 expect(arr[0].length).to.equal(5);
                 expect((arr as any).meta.id.equals(pk1)).to.be.true;
 
                 arr.push(makeAgents(16, 10));
 
-                expect(myGame.agents.getAgentManager(pk1)).to.deep.equal({
-                    id: pk1,
+                smartObjectEquals(myGame.agents.getAgentManager(pk1), {
+                    meta: testMeta(pk1),
                     game: myGame,
                     0: [
                         {
@@ -1169,10 +1185,8 @@ describe("Agents", function() {
                     ]
                 });
 
-                expect(
-                    arr[1].find(dummy => dummy.health % 9 == 0)
-                ).to.deep.equal({
-                    id: pk8.plus(3),
+                smartObjectEquals(arr[1].find(dummy => dummy.health % 9 == 0), {
+                    meta: testMeta(pk8.plus(3)),
                     name: "D18",
                     health: 18
                 });

--- a/test/unit/agents.test.ts
+++ b/test/unit/agents.test.ts
@@ -206,8 +206,10 @@ describe("Agents", function() {
             Game.init(MD);
 
             const myGame = buildGameInstance();
-            const parent = myGame.using(new Parent(new Dummy("D1", 10)));
-
+            // const parent = myGame.using(new Parent(new Dummy("D1", 10)));
+            const child = new Dummy("D1", 10);
+            let parent = new Parent(child);
+            parent = myGame.using(parent);
             expect(parent.child.name).to.equal("D1");
             expect(parent.child.health).to.equal(10);
         });
@@ -490,7 +492,7 @@ describe("Agents", function() {
             newChild(PARENT)(myGame1);
 
             expect(
-                myGame1.state.parent.child.id.equals(
+                myGame1.state.parent.child.meta.id.equals(
                     getGameInstancePK().plus(3)
                 )
             ).to.be.true;
@@ -503,7 +505,7 @@ describe("Agents", function() {
             newChild(myParent)(myGame2);
 
             expect(
-                myGame2.state.parent.child.id.equals(
+                myGame2.state.parent.child.meta.id.equals(
                     getGameInstancePK().plus(5)
                 )
             ).to.be.true;
@@ -516,7 +518,7 @@ describe("Agents", function() {
             newChild(myParent2)(myGame3);
 
             expect(
-                myGame3.state.parent.child.id.equals(
+                myGame3.state.parent.child.meta.id.equals(
                     getGameInstancePK().plus(4)
                 )
             ).to.be.true;
@@ -942,10 +944,10 @@ describe("Agents", function() {
 
                 const [_pk0, _pk1, pk2, pk3] = aPKs(3);
 
-                expect(d1.id.equals(pk2)).to.be.true;
+                expect(d1.meta.id.equals(pk2)).to.be.true;
                 expect(d1.name).to.equal("D1");
                 expect(d1.health).to.equal(10);
-                expect(d2.id.equals(pk3)).to.be.true;
+                expect(d2.meta.id.equals(pk3)).to.be.true;
                 expect(d2.name).to.equal("D2");
                 expect(d2.health).to.equal(15);
             });
@@ -1006,7 +1008,7 @@ describe("Agents", function() {
 
                 expect(
                     myGame.state.dummies.map(dummy => ({
-                        id: dummy.id,
+                        id: dummy.meta.id,
                         name: dummy.name,
                         health: dummy.health
                     }))
@@ -1130,7 +1132,7 @@ describe("Agents", function() {
                 ]);
                 expect(arr.length).to.equal(1);
                 expect(arr[0].length).to.equal(5);
-                expect((arr as any).id.equals(pk1)).to.be.true;
+                expect((arr as any).meta.id.equals(pk1)).to.be.true;
 
                 arr.push(makeAgents(16, 10));
 
@@ -1647,9 +1649,9 @@ describe("Agents", function() {
             const myGame = buildGameInstance();
 
             const d = myGame.using(new Dummy("D1", 15));
-            const dr = myGame.agents.getAgentManager(d.id);
+            const dr = myGame.agents.getAgentManager(d.meta.id);
 
-            expect(d.id).to.equal(dr.id);
+            expect(d.meta.id).to.equal(dr.meta.id);
         });
 
         it("The AgentManager's id matches the game instance", function() {
@@ -1658,7 +1660,7 @@ describe("Agents", function() {
             const myGame = buildGameInstance();
 
             const d = myGame.using(new Dummy("D1", 15));
-            const dr = myGame.agents.getAgentManager(d.id);
+            const dr = myGame.agents.getAgentManager(d.meta.id);
 
             expect(dr.game).to.equal(myGame);
         });
@@ -1669,7 +1671,7 @@ describe("Agents", function() {
             const myGame = buildGameInstance();
 
             const d = myGame.using(new Dummy("D1", 15));
-            const dr = myGame.agents.getAgentManager(d.id);
+            const dr = myGame.agents.getAgentManager(d.meta.id);
 
             delete d.health;
 
@@ -1688,7 +1690,7 @@ describe("Agents", function() {
             const d = myGame.using(DUMMY);
             d.health += 15;
 
-            const dr = myGame.agents.getAgentManager(d.id);
+            const dr = myGame.agents.getAgentManager(d.meta.id);
 
             expect(dr.hasPropertyRecord("name")).to.be.false;
             expect(dr.hasPropertyRecord("health")).to.be.true;
@@ -1711,7 +1713,7 @@ describe("Agents", function() {
             const d = myGame.using(new Dummy("D1", 15));
             d.health += 15;
 
-            const dr = myGame.agents.getAgentManager(d.id);
+            const dr = myGame.agents.getAgentManager(d.meta.id);
 
             expect(dr.getProperty("name")).to.equal("D1");
             expect(dr.getProperty("health")).to.equal(30);
@@ -1723,7 +1725,7 @@ describe("Agents", function() {
 
             const myGame = buildGameInstance();
             const d = myGame.using(new Dummy("D1", 15));
-            const dr = myGame.agents.getAgentManager(d.id);
+            const dr = myGame.agents.getAgentManager(d.meta.id);
             const [epk0, epk1] = ePKs(1);
 
             const addHealth = (dummy: Dummy) =>
@@ -1779,7 +1781,7 @@ describe("Agents", function() {
 
             addHealth(d)(myGame);
 
-            const dr = myGame.agents.getAgentManager(d.id);
+            const dr = myGame.agents.getAgentManager(d.meta.id);
             const [epk0, epk1] = ePKs(1);
 
             expect(dr.getPropertyHistory("name")).to.deep.equal([]);
@@ -1823,7 +1825,7 @@ describe("Agents", function() {
 
             delete (d as any).foo3;
 
-            const dr = myGame.agents.getAgentManager(d.id);
+            const dr = myGame.agents.getAgentManager(d.meta.id);
 
             expect(dr.propertyWasDeleted("name")).to.be.true;
             expect(dr.propertyWasDeleted("health")).to.be.false;
@@ -1840,7 +1842,7 @@ describe("Agents", function() {
 
             d.name = "D1";
 
-            const dr = myGame.agents.getAgentManager(d.id);
+            const dr = myGame.agents.getAgentManager(d.meta.id);
 
             expect(dr.getPropertyHistory("name")).to.deep.equal([
                 {
@@ -1863,7 +1865,7 @@ describe("Agents", function() {
 
             d.name = "D1";
 
-            const dr = myGame.agents.getAgentManager(d.id);
+            const dr = myGame.agents.getAgentManager(d.meta.id);
 
             expect(dr.getPropertyHistory("name")).to.deep.equal([]);
         });
@@ -1878,7 +1880,7 @@ describe("Agents", function() {
             delete d.name;
             delete d.name;
 
-            const dr = myGame.agents.getAgentManager(d.id);
+            const dr = myGame.agents.getAgentManager(d.meta.id);
 
             expect(dr.getPropertyHistory("name")).to.deep.equal([
                 {
@@ -2329,10 +2331,10 @@ describe("Agents", function() {
 
             const myGame = buildGameInstance();
 
-            expect(myGame.agents.reserveNewId().equals(DUMMY.id.plus(1))).to.be
-                .true;
-            expect(myGame.agents.reserveNewId().equals(DUMMY.id.plus(2))).to.be
-                .true;
+            expect(myGame.agents.reserveNewId().equals(DUMMY.meta.id.plus(1)))
+                .to.be.true;
+            expect(myGame.agents.reserveNewId().equals(DUMMY.meta.id.plus(2)))
+                .to.be.true;
         });
 
         it("InstanceAgents.getAgentProperty gets the correct property from either the instance or static registry", function() {
@@ -2347,9 +2349,13 @@ describe("Agents", function() {
             d.health += 5;
             (d as any).foo = true;
 
-            expect(myGame.agents.getAgentProperty(d.id, "name")).to.equal("D1");
-            expect(myGame.agents.getAgentProperty(d.id, "health")).to.equal(5);
-            expect(myGame.agents.getAgentProperty(d.id, "foo")).to.be.true;
+            expect(myGame.agents.getAgentProperty(d.meta.id, "name")).to.equal(
+                "D1"
+            );
+            expect(
+                myGame.agents.getAgentProperty(d.meta.id, "health")
+            ).to.equal(5);
+            expect(myGame.agents.getAgentProperty(d.meta.id, "foo")).to.be.true;
         });
 
         it("If the static agent hasn't been modified, InstanceAgents.getAgentProperty will call the static registry directly", function() {
@@ -2361,13 +2367,16 @@ describe("Agents", function() {
 
             const d = myGame.using(DUMMY);
 
-            expect(myGame.agents.getAgentProperty(d.id, "name")).to.equal("D1");
-            expect(myGame.agents.getAgentProperty(d.id, "bad")).to.be.undefined;
+            expect(myGame.agents.getAgentProperty(d.meta.id, "name")).to.equal(
+                "D1"
+            );
+            expect(myGame.agents.getAgentProperty(d.meta.id, "bad")).to.be
+                .undefined;
             expect(
                 myGame.agents
                     .agentManagers()
-                    .map(manager => manager.id)
-                    .includes(d.id)
+                    .map(manager => manager.meta.id)
+                    .includes(d.meta.id)
             ).to.be.false; // There isn't an agent manager for this agent
         });
 
@@ -2416,7 +2425,7 @@ describe("Agents", function() {
                 name: "D1",
                 health: 10
             });
-            expect(child.id).to.equal(DUMMY.id);
+            expect(child.meta.id).to.equal(DUMMY.meta.id);
             expect(child.name).to.equal("D1");
         });
 
@@ -2426,7 +2435,7 @@ describe("Agents", function() {
             const myGame = buildGameInstance();
             const d = myGame.using(new Dummy("D1", 10));
 
-            myGame.agents.setAgentProperty(d.id, "name", "Lars");
+            myGame.agents.setAgentProperty(d.meta.id, "name", "Lars");
 
             expect(d.name).to.equal("Lars");
         });
@@ -2500,10 +2509,12 @@ describe("Agents", function() {
 
             const myGame = buildGameInstance();
 
-            expect(myGame.agents.hasAgentProperty(DUMMY.id, "name")).to.be.true;
-            expect(myGame.agents.hasAgentProperty(DUMMY.id, "health")).to.be
+            expect(myGame.agents.hasAgentProperty(DUMMY.meta.id, "name")).to.be
                 .true;
-            expect(myGame.agents.hasAgentProperty(DUMMY.id, "foo")).to.be.false;
+            expect(myGame.agents.hasAgentProperty(DUMMY.meta.id, "health")).to
+                .be.true;
+            expect(myGame.agents.hasAgentProperty(DUMMY.meta.id, "foo")).to.be
+                .false;
         });
 
         it("InstanceAgents.hasAgentProperty works properly with static agents that have been modified in the cycle", function() {
@@ -2515,10 +2526,12 @@ describe("Agents", function() {
 
             myGame.using(DUMMY).health += 15;
 
-            expect(myGame.agents.hasAgentProperty(DUMMY.id, "name")).to.be.true;
-            expect(myGame.agents.hasAgentProperty(DUMMY.id, "health")).to.be
+            expect(myGame.agents.hasAgentProperty(DUMMY.meta.id, "name")).to.be
                 .true;
-            expect(myGame.agents.hasAgentProperty(DUMMY.id, "foo")).to.be.false;
+            expect(myGame.agents.hasAgentProperty(DUMMY.meta.id, "health")).to
+                .be.true;
+            expect(myGame.agents.hasAgentProperty(DUMMY.meta.id, "foo")).to.be
+                .false;
         });
 
         it("InstanceAgents.hasAgentProperty works properly with nonstatic agents", function() {
@@ -2527,10 +2540,12 @@ describe("Agents", function() {
             const myGame = buildGameInstance();
             const dummy = myGame.using(new Dummy("D1", 10));
 
-            expect(myGame.agents.hasAgentProperty(dummy.id, "name")).to.be.true;
-            expect(myGame.agents.hasAgentProperty(dummy.id, "health")).to.be
+            expect(myGame.agents.hasAgentProperty(dummy.meta.id, "name")).to.be
                 .true;
-            expect(myGame.agents.hasAgentProperty(dummy.id, "foo")).to.be.false;
+            expect(myGame.agents.hasAgentProperty(dummy.meta.id, "health")).to
+                .be.true;
+            expect(myGame.agents.hasAgentProperty(dummy.meta.id, "foo")).to.be
+                .false;
         });
 
         it("Error check for InstanceAgents.hasAgentProperty with an invalid id", function() {
@@ -2553,8 +2568,8 @@ describe("Agents", function() {
             const myGame = buildGameInstance();
             const d = myGame.using(DUMMY);
 
-            myGame.agents.deleteAgentProperty(d.id, "name");
-            myGame.agents.deleteAgentProperty(d.id, "foo");
+            myGame.agents.deleteAgentProperty(d.meta.id, "name");
+            myGame.agents.deleteAgentProperty(d.meta.id, "foo");
 
             expect("name" in d).to.be.false;
             expect(d.name).to.be.undefined;
@@ -2569,8 +2584,8 @@ describe("Agents", function() {
             const myGame = buildGameInstance();
             const d = myGame.using(new Dummy("D1", 10));
 
-            myGame.agents.deleteAgentProperty(d.id, "name");
-            myGame.agents.deleteAgentProperty(d.id, "foo");
+            myGame.agents.deleteAgentProperty(d.meta.id, "name");
+            myGame.agents.deleteAgentProperty(d.meta.id, "foo");
 
             expect("name" in d).to.be.false;
             expect(d.name).to.be.undefined;
@@ -2585,7 +2600,7 @@ describe("Agents", function() {
             const dummy = myGame.using(new Dummy("D1", 10));
 
             expect(() =>
-                myGame.agents.deleteAgentProperty(dummy.id, "id")
+                myGame.agents.deleteAgentProperty(dummy.meta.id, "id")
             ).to.throw(
                 RegalError,
                 "The agent's <id> property cannot be deleted."
@@ -2600,7 +2615,7 @@ describe("Agents", function() {
             const dummy = myGame.using(new Dummy("D1", 10));
 
             expect(() =>
-                myGame.agents.deleteAgentProperty(dummy.id, "game")
+                myGame.agents.deleteAgentProperty(dummy.meta.id, "game")
             ).to.throw(
                 RegalError,
                 "The agent's <game> property cannot be deleted."
@@ -2628,7 +2643,7 @@ describe("Agents", function() {
             const d = myGame.using(new Dummy("D1", 10));
 
             expect(
-                myGame.agents.getAgentManager(d.id).getProperty("name")
+                myGame.agents.getAgentManager(d.meta.id).getProperty("name")
             ).to.equal("D1");
         });
 
@@ -2661,11 +2676,11 @@ describe("Agents", function() {
         it("StaticAgentRegistry.hasAgentProperty works properly", function() {
             const D = new Dummy("D1", 10);
 
-            expect(StaticAgentRegistry.hasAgentProperty(D.id, "name")).to.be
-                .true;
-            expect(StaticAgentRegistry.hasAgentProperty(D.id, "health")).to.be
-                .true;
-            expect(StaticAgentRegistry.hasAgentProperty(D.id, "foo")).to.be
+            expect(StaticAgentRegistry.hasAgentProperty(D.meta.id, "name")).to
+                .be.true;
+            expect(StaticAgentRegistry.hasAgentProperty(D.meta.id, "health")).to
+                .be.true;
+            expect(StaticAgentRegistry.hasAgentProperty(D.meta.id, "foo")).to.be
                 .false;
         });
 
@@ -2678,13 +2693,13 @@ describe("Agents", function() {
 
             (d as any).bar = true;
 
-            expect(StaticAgentRegistry.hasAgentProperty(D.id, "name")).to.be
+            expect(StaticAgentRegistry.hasAgentProperty(D.meta.id, "name")).to
+                .be.true;
+            expect(StaticAgentRegistry.hasAgentProperty(D.meta.id, "health")).to
+                .be.true;
+            expect(StaticAgentRegistry.hasAgentProperty(D.meta.id, "foo")).to.be
                 .true;
-            expect(StaticAgentRegistry.hasAgentProperty(D.id, "health")).to.be
-                .true;
-            expect(StaticAgentRegistry.hasAgentProperty(D.id, "foo")).to.be
-                .true;
-            expect(StaticAgentRegistry.hasAgentProperty(D.id, "bar")).to.be
+            expect(StaticAgentRegistry.hasAgentProperty(D.meta.id, "bar")).to.be
                 .false;
         });
 
@@ -2692,16 +2707,16 @@ describe("Agents", function() {
             const D = new Dummy("D1", 10);
             const P = new Parent(D);
 
-            expect(StaticAgentRegistry.getAgentProperty(D.id, "name")).to.equal(
-                "D1"
-            );
             expect(
-                StaticAgentRegistry.getAgentProperty(D.id, "health")
+                StaticAgentRegistry.getAgentProperty(D.meta.id, "name")
+            ).to.equal("D1");
+            expect(
+                StaticAgentRegistry.getAgentProperty(D.meta.id, "health")
             ).to.equal(10);
-            expect(StaticAgentRegistry.getAgentProperty(D.id, "foo")).to.be
+            expect(StaticAgentRegistry.getAgentProperty(D.meta.id, "foo")).to.be
                 .undefined;
             expect(
-                StaticAgentRegistry.getAgentProperty(P.id, "child")
+                StaticAgentRegistry.getAgentProperty(P.meta.id, "child")
             ).to.equal(D);
         });
 
@@ -2727,7 +2742,7 @@ describe("Agents", function() {
 
             const p = buildGameInstance().using(new Parent(D));
 
-            expect(StaticAgentRegistry.hasAgent(p.id)).to.be.false;
+            expect(StaticAgentRegistry.hasAgent(p.meta.id)).to.be.false;
         });
 
         it("StaticAgentRegistry.addAgent is called implicitly", function() {
@@ -2743,7 +2758,10 @@ describe("Agents", function() {
             const pk = getGameInstancePK().plus(22);
             expect(() =>
                 StaticAgentRegistry.addAgent({
-                    id: pk
+                    meta: {
+                        id: pk,
+                        protoId: null // TODO
+                    }
                 })
             ).to.throw(
                 RegalError,
@@ -2783,7 +2801,7 @@ describe("Agents", function() {
             const pks0_3 = aPKs(3);
 
             expect(
-                myGame.agents.agentManagers().map(am => am.id)
+                myGame.agents.agentManagers().map(am => am.meta.id)
             ).to.deep.equal(pks0_3);
             expect(myGame.state.dummy).to.deep.equal({
                 id: pks0_3[1],
@@ -2800,7 +2818,7 @@ describe("Agents", function() {
             myGame.agents.scrubAgents();
 
             expect(
-                myGame.agents.agentManagers().map(am => am.id)
+                myGame.agents.agentManagers().map(am => am.meta.id)
             ).to.deep.equal(aPKs(2));
             expect(myGame.state.dummy).to.deep.equal({
                 id: pks0_3[1],
@@ -2831,7 +2849,7 @@ describe("Agents", function() {
             const pks0_6 = aPKs(6);
 
             expect(
-                myGame.agents.agentManagers().map(am => am.id)
+                myGame.agents.agentManagers().map(am => am.meta.id)
             ).to.deep.equal(pks0_6);
             expect(myGame.state.arr[3]).to.deep.equal({
                 id: pks0_6[3],
@@ -2841,14 +2859,14 @@ describe("Agents", function() {
 
             myGame.agents.scrubAgents();
             expect(
-                myGame.agents.agentManagers().map(am => am.id)
+                myGame.agents.agentManagers().map(am => am.meta.id)
             ).to.deep.equal(pks0_6);
 
             myGame.state.arr.splice(2, 1);
             myGame.agents.scrubAgents();
 
             expect(
-                myGame.agents.agentManagers().map(am => am.id)
+                myGame.agents.agentManagers().map(am => am.meta.id)
             ).to.deep.equal([pks0_6[0], pks0_6[3], pks0_6[5], pks0_6[6]]);
             expect(myGame.state.arr[2]).to.deep.equal({
                 id: pks0_6[3],

--- a/test/unit/agents.test.ts
+++ b/test/unit/agents.test.ts
@@ -25,6 +25,7 @@ import { DEFAULT_EVENT_NAME, getUntrackedEventPK } from "../../src/events";
 import { on } from "../../src/events";
 import { buildGameInstance } from "../../src/state";
 import { STATIC_AGENT_PK_PROVIDER } from "../../src/agents/impl";
+import { ReservedAgentProperty } from "../../src/agents/agent-meta";
 
 class Parent extends Agent {
     constructor(public child: Dummy) {
@@ -1208,8 +1209,8 @@ describe("Agents", function() {
                 smartObjectEquals(myGame.agents, {
                     _pkProvider: TestProperty.REQUIRE_BUT_SKIP,
                     game: myGame,
-                    [pk0.value()]: {
-                        id: pk0,
+                    [pk0.value()]: smartObj({
+                        meta: testMeta(pk0),
                         game: myGame,
                         arr: [
                             {
@@ -1222,9 +1223,9 @@ describe("Agents", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    },
-                    [pk1.value()]: {
-                        id: pk1,
+                    }),
+                    [pk1.value()]: smartObj({
+                        meta: testMeta(pk1),
                         game: myGame,
                         0: [
                             {
@@ -1275,9 +1276,9 @@ describe("Agents", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    },
-                    [pk2.value()]: {
-                        id: pk2,
+                    }),
+                    [pk2.value()]: smartObj({
+                        meta: testMeta(pk2),
                         game: myGame,
                         0: [
                             {
@@ -1306,9 +1307,9 @@ describe("Agents", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    },
-                    [pk3.value()]: {
-                        id: pk3,
+                    }),
+                    [pk3.value()]: smartObj({
+                        meta: testMeta(pk3),
                         game: myGame,
                         name: [
                             {
@@ -1328,9 +1329,9 @@ describe("Agents", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    },
-                    [pk4.value()]: {
-                        id: pk4,
+                    }),
+                    [pk4.value()]: smartObj({
+                        meta: testMeta(pk4),
                         game: myGame,
                         name: [
                             {
@@ -1350,9 +1351,9 @@ describe("Agents", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    },
-                    [pk5.value()]: {
-                        id: pk5,
+                    }),
+                    [pk5.value()]: smartObj({
+                        meta: testMeta(pk5),
                         game: myGame,
                         0: [
                             {
@@ -1399,9 +1400,9 @@ describe("Agents", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    },
-                    [pk6.value()]: {
-                        id: pk6,
+                    }),
+                    [pk6.value()]: smartObj({
+                        meta: testMeta(pk6),
                         game: myGame,
                         name: [
                             {
@@ -1421,9 +1422,9 @@ describe("Agents", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    },
-                    [pk7.value()]: {
-                        id: pk7,
+                    }),
+                    [pk7.value()]: smartObj({
+                        meta: testMeta(pk7),
                         game: myGame,
                         name: [
                             {
@@ -1443,9 +1444,9 @@ describe("Agents", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    },
-                    [pk8.value()]: {
-                        id: pk8,
+                    }),
+                    [pk8.value()]: smartObj({
+                        meta: testMeta(pk8),
                         game: myGame,
                         name: [
                             {
@@ -1465,9 +1466,9 @@ describe("Agents", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    },
-                    [pk9.value()]: {
-                        id: pk9,
+                    }),
+                    [pk9.value()]: smartObj({
+                        meta: testMeta(pk9),
                         game: myGame,
                         name: [
                             {
@@ -1487,7 +1488,7 @@ describe("Agents", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    }
+                    })
                 });
             });
 
@@ -1498,18 +1499,21 @@ describe("Agents", function() {
 
                 const [pk0, pk1, pk2] = aPKs(2);
 
-                expect(p.children).to.deep.equal([
-                    {
-                        id: pk2,
-                        name: "D1",
-                        health: 10
-                    },
-                    {
-                        id: pk1,
-                        name: "D2",
-                        health: 10
-                    }
-                ]);
+                smartObjectEquals(
+                    [...p.children],
+                    [
+                        smartObj({
+                            meta: testMeta(pk2),
+                            name: "D1",
+                            health: 10
+                        }),
+                        smartObj({
+                            meta: testMeta(pk1),
+                            name: "D2",
+                            health: 10
+                        })
+                    ]
+                );
 
                 Game.init(MD);
 
@@ -1519,22 +1523,28 @@ describe("Agents", function() {
 
                 c.pop().name += " Jr.";
 
-                expect(p1.children).to.deep.equal([
-                    {
-                        id: pk2,
-                        name: "D1",
-                        health: 10
-                    }
-                ]);
-                expect(myGame1.using(q).children).to.deep.equal([
-                    {
-                        id: pk2,
-                        name: "D1",
-                        health: 10
-                    }
-                ]);
-                expect(myGame1.using(d2)).to.deep.equal({
-                    id: pk1,
+                smartObjectEquals(
+                    [...p1.children],
+                    [
+                        smartObj({
+                            meta: testMeta(pk2),
+                            name: "D1",
+                            health: 10
+                        })
+                    ]
+                );
+                smartObjectEquals(
+                    [...myGame1.using(q).children],
+                    [
+                        smartObj({
+                            meta: testMeta(pk2),
+                            name: "D1",
+                            health: 10
+                        })
+                    ]
+                );
+                smartObjectEquals(myGame1.using(d2), {
+                    meta: testMeta(pk1),
                     name: "D2 Jr.",
                     health: 10
                 });
@@ -1543,62 +1553,76 @@ describe("Agents", function() {
                 const p2 = myGame2.using(p);
                 p2.children.push(new Dummy("D3", 5), d2);
 
-                expect(p2.children).to.deep.equal([
-                    {
-                        id: pk2,
-                        name: "D1",
-                        health: 10
-                    },
-                    {
-                        id: pk1,
-                        name: "D2",
-                        health: 10
-                    },
-                    {
-                        id: pk0.plus(6),
-                        name: "D3",
-                        health: 5
-                    },
-                    {
-                        id: pk1,
-                        name: "D2",
-                        health: 10
-                    }
-                ]);
+                smartObjectEquals(
+                    [...p2.children],
+                    [
+                        smartObj({
+                            meta: testMeta(pk2),
+                            name: "D1",
+                            health: 10
+                        }),
+                        smartObj({
+                            meta: testMeta(pk1),
+                            name: "D2",
+                            health: 10
+                        }),
+                        smartObj({
+                            meta: testMeta(pk0.plus(6)),
+                            name: "D3",
+                            health: 5
+                        }),
+                        smartObj({
+                            meta: testMeta(pk1),
+                            name: "D2",
+                            health: 10
+                        })
+                    ]
+                );
                 expect(myGame2.using(q).children).to.deep.equal(p2.children);
 
                 // Verify that initial conditions still hold
-                expect(buildGameInstance().using(p).children).to.deep.equal([
-                    {
-                        id: pk2,
-                        name: "D1",
-                        health: 10
-                    },
-                    {
-                        id: pk1,
-                        name: "D2",
-                        health: 10
-                    }
-                ]);
-                expect(buildGameInstance().using(q).children).to.deep.equal([
-                    {
-                        id: pk2,
-                        name: "D1",
-                        health: 10
-                    },
-                    {
-                        id: pk1,
-                        name: "D2",
-                        health: 10
-                    }
-                ]);
+                smartObjectEquals(
+                    [...buildGameInstance().using(p).children],
+                    [
+                        smartObj({
+                            meta: testMeta(pk2),
+                            name: "D1",
+                            health: 10
+                        }),
+                        smartObj({
+                            meta: testMeta(pk1),
+                            name: "D2",
+                            health: 10
+                        })
+                    ]
+                );
+                smartObjectEquals(
+                    [...buildGameInstance().using(q).children],
+                    [
+                        smartObj({
+                            meta: testMeta(pk2),
+                            name: "D1",
+                            health: 10
+                        }),
+                        smartObj({
+                            meta: testMeta(pk1),
+                            name: "D2",
+                            health: 10
+                        })
+                    ]
+                );
             });
 
             it("An agent array's keys enumerate properly", function() {
                 Game.init(MD);
 
                 const a = buildGameInstance().using([1, 2, 3]);
-                expect(Object.keys(a)).to.deep.equal(["0", "1", "2", "id"]);
+                expect(Object.keys(a)).to.deep.equal([
+                    "0",
+                    "1",
+                    "2",
+                    ReservedAgentProperty.META
+                ]);
             });
 
             it("Adding an agent to an array via Array.prototype.push activates the agent", function() {
@@ -1611,13 +1635,16 @@ describe("Agents", function() {
                 const myGame = buildGameInstance();
                 myEvent(myGame);
 
-                expect(myGame.state.list).to.deep.equal([
-                    {
-                        id: getGameInstancePK().plus(2),
-                        name: "D1",
-                        health: 10
-                    }
-                ]);
+                smartObjectEquals(
+                    [...myGame.state.list],
+                    [
+                        smartObj({
+                            meta: testMeta(getGameInstancePK().plus(2)),
+                            name: "D1",
+                            health: 10
+                        })
+                    ]
+                );
                 expect(
                     myGame.agents.getAgentProperty(
                         getGameInstancePK().plus(2),
@@ -1934,8 +1961,8 @@ describe("Agents", function() {
             smartObjectEquals(myGame.agents, {
                 _pkProvider: TestProperty.REQUIRE_BUT_SKIP,
                 game: myGame,
-                [pk0.value()]: {
-                    id: pk0,
+                [pk0.value()]: smartObj({
+                    meta: testMeta(pk0),
                     game: myGame,
                     dummy: [
                         {
@@ -1957,9 +1984,9 @@ describe("Agents", function() {
                             op: PropertyOperation.ADDED
                         }
                     ]
-                },
-                [pk1.value()]: {
-                    id: pk1,
+                }),
+                [pk1.value()]: smartObj({
+                    meta: testMeta(pk1),
                     game: myGame,
                     name: [
                         {
@@ -1986,7 +2013,7 @@ describe("Agents", function() {
                             op: PropertyOperation.ADDED
                         }
                     ]
-                }
+                })
             });
 
             const myGame2 = myGame.recycle();
@@ -1994,8 +2021,8 @@ describe("Agents", function() {
             smartObjectEquals(myGame2.agents, {
                 _pkProvider: TestProperty.REQUIRE_BUT_SKIP,
                 game: myGame2,
-                [pk0.value()]: {
-                    id: pk0,
+                [pk0.value()]: smartObj({
+                    meta: testMeta(pk0),
                     game: myGame2,
                     dummy: [
                         {
@@ -2017,9 +2044,9 @@ describe("Agents", function() {
                             op: PropertyOperation.ADDED
                         }
                     ]
-                },
-                [pk1.value()]: {
-                    id: pk1,
+                }),
+                [pk1.value()]: smartObj({
+                    meta: testMeta(pk1),
                     game: myGame2,
                     name: [
                         {
@@ -2039,7 +2066,7 @@ describe("Agents", function() {
                             op: PropertyOperation.ADDED
                         }
                     ]
-                }
+                })
             });
         });
 
@@ -2064,8 +2091,8 @@ describe("Agents", function() {
             smartObjectEquals(myGame.agents, {
                 _pkProvider: TestProperty.REQUIRE_BUT_SKIP,
                 game: myGame,
-                [pk0.value()]: {
-                    id: pk0,
+                [pk0.value()]: smartObj({
+                    meta: testMeta(pk0),
                     game: myGame,
                     dummy: [
                         {
@@ -2087,9 +2114,9 @@ describe("Agents", function() {
                             op: PropertyOperation.ADDED
                         }
                     ]
-                },
-                [pk1.value()]: {
-                    id: pk1,
+                }),
+                [pk1.value()]: smartObj({
+                    meta: testMeta(pk1),
                     game: myGame,
                     name: [
                         {
@@ -2109,7 +2136,7 @@ describe("Agents", function() {
                             op: PropertyOperation.ADDED
                         }
                     ]
-                }
+                })
             });
 
             const myGame2 = myGame.recycle();
@@ -2117,8 +2144,8 @@ describe("Agents", function() {
             smartObjectEquals(myGame2.agents, {
                 _pkProvider: TestProperty.REQUIRE_BUT_SKIP,
                 game: myGame2,
-                [pk0.value()]: {
-                    id: pk0,
+                [pk0.value()]: smartObj({
+                    meta: testMeta(pk0),
                     game: myGame2,
                     dummy: [
                         {
@@ -2140,9 +2167,9 @@ describe("Agents", function() {
                             op: PropertyOperation.ADDED
                         }
                     ]
-                },
-                [pk1.value()]: {
-                    id: pk1,
+                }),
+                [pk1.value()]: smartObj({
+                    meta: testMeta(pk1),
                     game: myGame2,
                     name: [
                         {
@@ -2162,7 +2189,7 @@ describe("Agents", function() {
                             op: PropertyOperation.ADDED
                         }
                     ]
-                }
+                })
             });
         });
 
@@ -2190,8 +2217,8 @@ describe("Agents", function() {
             smartObjectEquals(game2.agents, {
                 _pkProvider: TestProperty.REQUIRE_BUT_SKIP,
                 game: game2,
-                [pk0.value()]: {
-                    id: pk0,
+                [pk0.value()]: smartObj({
+                    meta: testMeta(pk0),
                     game: game2,
                     dummy: [
                         {
@@ -2213,9 +2240,9 @@ describe("Agents", function() {
                             op: PropertyOperation.ADDED
                         }
                     ]
-                },
-                [pk1.value()]: {
-                    id: pk1,
+                }),
+                [pk1.value()]: smartObj({
+                    meta: testMeta(pk1),
                     game: game2,
                     name: [
                         {
@@ -2226,7 +2253,7 @@ describe("Agents", function() {
                             op: PropertyOperation.MODIFIED
                         }
                     ]
-                }
+                })
             });
         });
 
@@ -2251,8 +2278,8 @@ describe("Agents", function() {
             smartObjectEquals(game2.agents, {
                 _pkProvider: TestProperty.REQUIRE_BUT_SKIP,
                 game: game2,
-                [pk0.value()]: {
-                    id: pk0,
+                [pk0.value()]: smartObj({
+                    meta: testMeta(pk0),
                     game: game2,
                     dummy: [
                         {
@@ -2265,9 +2292,9 @@ describe("Agents", function() {
                             op: PropertyOperation.ADDED
                         }
                     ]
-                },
-                [pk1.value()]: {
-                    id: pk1,
+                }),
+                [pk1.value()]: smartObj({
+                    meta: testMeta(pk1),
                     game: game2,
                     health: [
                         {
@@ -2278,7 +2305,7 @@ describe("Agents", function() {
                             op: PropertyOperation.ADDED
                         }
                     ]
-                }
+                })
             });
         });
 
@@ -2304,8 +2331,8 @@ describe("Agents", function() {
             smartObjectEquals(game2.agents, {
                 _pkProvider: TestProperty.REQUIRE_BUT_SKIP,
                 game: game2,
-                [pk0.value()]: {
-                    id: pk0,
+                [pk0.value()]: smartObj({
+                    meta: testMeta(pk0),
                     game: game2,
                     dummy: [
                         {
@@ -2318,9 +2345,9 @@ describe("Agents", function() {
                             op: PropertyOperation.ADDED
                         }
                     ]
-                },
-                [pk1.value()]: {
-                    id: pk1,
+                }),
+                [pk1.value()]: smartObj({
+                    meta: testMeta(pk1),
                     game: game2,
                     name: [
                         {
@@ -2331,7 +2358,7 @@ describe("Agents", function() {
                             op: PropertyOperation.DELETED
                         }
                     ]
-                }
+                })
             });
         });
 
@@ -2431,8 +2458,8 @@ describe("Agents", function() {
                 getGameInstancePK().plus(2),
                 "child"
             );
-            expect(child).to.deep.equal({
-                id: getGameInstancePK().plus(1),
+            smartObjectEquals(child, {
+                meta: testMeta(getGameInstancePK().plus(1)),
                 name: "D1",
                 health: 10
             });
@@ -2469,7 +2496,7 @@ describe("Agents", function() {
             expect(buildGameInstance().using(SIB).sibling).to.be.undefined;
         });
 
-        it("Error check InstanceAgents.setAgentProperty with id", function() {
+        it("Error check InstanceAgents.setAgentProperty with meta", function() {
             Game.init(MD);
 
             const myGame = buildGameInstance();
@@ -2478,10 +2505,13 @@ describe("Agents", function() {
             expect(() =>
                 myGame.agents.setAgentProperty(
                     getGameInstancePK().plus(1),
-                    "id",
+                    ReservedAgentProperty.META,
                     2
                 )
-            ).to.throw(RegalError, "The agent's <id> property cannot be set.");
+            ).to.throw(
+                RegalError,
+                "The agent's <meta> property cannot be set."
+            );
         });
 
         it("Error check InstanceAgents.setAgentProperty with game", function() {
@@ -2493,7 +2523,7 @@ describe("Agents", function() {
             expect(() =>
                 myGame.agents.setAgentProperty(
                     getGameInstancePK().plus(1),
-                    "game",
+                    ReservedAgentProperty.GAME,
                     buildGameInstance()
                 )
             ).to.throw(
@@ -2603,7 +2633,7 @@ describe("Agents", function() {
             expect("health" in d).to.be.true;
         });
 
-        it("Error check for InstanceAgents.deleteAgentProperty refuse delete of id", function() {
+        it("Error check for InstanceAgents.deleteAgentProperty refuse delete of meta", function() {
             Game.init(MD);
 
             const myGame = buildGameInstance();
@@ -2611,10 +2641,13 @@ describe("Agents", function() {
             const dummy = myGame.using(new Dummy("D1", 10));
 
             expect(() =>
-                myGame.agents.deleteAgentProperty(dummy.meta.id, "id")
+                myGame.agents.deleteAgentProperty(
+                    dummy.meta.id,
+                    ReservedAgentProperty.META
+                )
             ).to.throw(
                 RegalError,
-                "The agent's <id> property cannot be deleted."
+                "The agent's <meta> property cannot be deleted."
             );
         });
 
@@ -2771,7 +2804,7 @@ describe("Agents", function() {
                 StaticAgentRegistry.addAgent({
                     meta: {
                         id: pk,
-                        protoId: null // TODO
+                        protoId: undefined
                     }
                 })
             ).to.throw(
@@ -2814,13 +2847,13 @@ describe("Agents", function() {
             expect(
                 myGame.agents.agentManagers().map(am => am.meta.id)
             ).to.deep.equal(pks0_3);
-            expect(myGame.state.dummy).to.deep.equal({
-                id: pks0_3[1],
-                child: {
-                    id: pks0_3[2],
+            smartObjectEquals(myGame.state.dummy, {
+                meta: testMeta(pks0_3[1]),
+                child: smartObj({
+                    meta: testMeta(pks0_3[2]),
                     name: "D1",
                     health: 10
-                }
+                })
             });
             expect(myGame.agents.getAgentProperty(pks0_3[3], "name")).to.equal(
                 "D2"
@@ -2831,13 +2864,13 @@ describe("Agents", function() {
             expect(
                 myGame.agents.agentManagers().map(am => am.meta.id)
             ).to.deep.equal(aPKs(2));
-            expect(myGame.state.dummy).to.deep.equal({
-                id: pks0_3[1],
-                child: {
-                    id: pks0_3[2],
+            smartObjectEquals(myGame.state.dummy, {
+                meta: testMeta(pks0_3[1]),
+                child: smartObj({
+                    meta: testMeta(pks0_3[2]),
                     name: "D1",
                     health: 10
-                }
+                })
             });
 
             expect(() =>
@@ -2862,8 +2895,8 @@ describe("Agents", function() {
             expect(
                 myGame.agents.agentManagers().map(am => am.meta.id)
             ).to.deep.equal(pks0_6);
-            expect(myGame.state.arr[3]).to.deep.equal({
-                id: pks0_6[3],
+            smartObjectEquals(myGame.state.arr[3], {
+                meta: testMeta(pks0_6[3]),
                 name: "D1",
                 health: 1
             });
@@ -2879,8 +2912,8 @@ describe("Agents", function() {
             expect(
                 myGame.agents.agentManagers().map(am => am.meta.id)
             ).to.deep.equal([pks0_6[0], pks0_6[3], pks0_6[5], pks0_6[6]]);
-            expect(myGame.state.arr[2]).to.deep.equal({
-                id: pks0_6[3],
+            smartObjectEquals(myGame.state.arr[2], {
+                meta: testMeta(pks0_6[3]),
                 name: "D1",
                 health: 1
             });

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -683,8 +683,8 @@ describe("Config", function() {
                 smartObjectEquals(responseInstance.agents, {
                     _pkProvider: TestProperty.REQUIRE_BUT_SKIP,
                     game: response.instance,
-                    [apk0.value()]: {
-                        id: apk0,
+                    [apk0.value()]: smartObj({
+                        meta: testMeta(apk0),
                         game: response.instance,
                         dummyCount: [
                             {
@@ -711,9 +711,9 @@ describe("Config", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    },
-                    [apk1.value()]: {
-                        id: apk1,
+                    }),
+                    [apk1.value()]: smartObj({
+                        meta: testMeta(apk1),
                         game: response.instance,
                         name: [
                             {
@@ -733,7 +733,7 @@ describe("Config", function() {
                                 op: PropertyOperation.MODIFIED
                             }
                         ]
-                    }
+                    })
                 });
                 expect(responseInstance.events.history).to.deep.equal([
                     {

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -285,8 +285,8 @@ describe("Config", function() {
                 smartObjectEquals(responseInstance.agents, {
                     _pkProvider: TestProperty.REQUIRE_BUT_SKIP,
                     game: response.instance,
-                    [apk0.value()]: {
-                        id: apk0,
+                    [apk0.value()]: smartObj({
+                        meta: testMeta(apk0),
                         game: response.instance,
                         dummyCount: [
                             {
@@ -297,7 +297,7 @@ describe("Config", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    }
+                    })
                 });
                 expect(responseInstance.events.history).to.deep.equal([
                     {
@@ -327,8 +327,8 @@ describe("Config", function() {
                 smartObjectEquals(responseInstance.agents, {
                     _pkProvider: TestProperty.REQUIRE_BUT_SKIP,
                     game: response.instance,
-                    [apk0.value()]: {
-                        id: apk0,
+                    [apk0.value()]: smartObj({
+                        meta: testMeta(apk0),
                         game: response.instance,
                         dummyCount: [
                             {
@@ -355,9 +355,9 @@ describe("Config", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    },
-                    [apk1.value()]: {
-                        id: apk1,
+                    }),
+                    [apk1.value()]: smartObj({
+                        meta: testMeta(apk1),
                         game: response.instance,
                         name: [
                             {
@@ -391,7 +391,7 @@ describe("Config", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    }
+                    })
                 });
                 expect(responseInstance.events.history).to.deep.equal([
                     {
@@ -465,8 +465,8 @@ describe("Config", function() {
                 smartObjectEquals(responseInstance.agents, {
                     _pkProvider: TestProperty.REQUIRE_BUT_SKIP,
                     game: response.instance,
-                    [apk0.value()]: {
-                        id: apk0,
+                    [apk0.value()]: smartObj({
+                        meta: testMeta(apk0),
                         game: response.instance,
                         dummyCount: [
                             {
@@ -500,9 +500,9 @@ describe("Config", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    },
-                    [apk1.value()]: {
-                        id: apk1,
+                    }),
+                    [apk1.value()]: smartObj({
+                        meta: testMeta(apk1),
                         game: response.instance,
                         name: [
                             {
@@ -522,9 +522,9 @@ describe("Config", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    },
-                    [apk2.value()]: {
-                        id: apk2,
+                    }),
+                    [apk2.value()]: smartObj({
+                        meta: testMeta(apk2),
                         game: response.instance,
                         name: [
                             {
@@ -558,7 +558,7 @@ describe("Config", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    }
+                    })
                 });
                 expect(responseInstance.events.history).to.deep.equal([
                     {
@@ -761,8 +761,8 @@ describe("Config", function() {
                 smartObjectEquals(responseInstance.agents, {
                     _pkProvider: TestProperty.REQUIRE_BUT_SKIP,
                     game: response.instance,
-                    [apk0.value()]: {
-                        id: apk0,
+                    [apk0.value()]: smartObj({
+                        meta: testMeta(apk0),
                         game: response.instance,
                         dummyCount: [
                             {
@@ -796,9 +796,9 @@ describe("Config", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    },
-                    [apk1.value()]: {
-                        id: apk1,
+                    }),
+                    [apk1.value()]: smartObj({
+                        meta: testMeta(apk1),
                         game: response.instance,
                         name: [
                             {
@@ -818,9 +818,9 @@ describe("Config", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    },
-                    [apk2.value()]: {
-                        id: apk2,
+                    }),
+                    [apk2.value()]: smartObj({
+                        meta: testMeta(apk2),
                         game: response.instance,
                         name: [
                             {
@@ -840,7 +840,7 @@ describe("Config", function() {
                                 op: PropertyOperation.MODIFIED
                             }
                         ]
-                    }
+                    })
                 });
                 expect(responseInstance.events.history).to.deep.equal([
                     {

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -21,7 +21,9 @@ import {
     TestProperty,
     aPKs,
     getInitialOutputPK,
-    ePKs
+    ePKs,
+    smartObj,
+    testMeta
 } from "../test-utils";
 import { on, DEFAULT_EVENT_NAME } from "../../src/events";
 import { Agent, PropertyOperation, getGameInstancePK } from "../../src/agents";
@@ -648,8 +650,8 @@ describe("Config", function() {
                 smartObjectEquals(responseInstance.agents, {
                     _pkProvider: TestProperty.REQUIRE_BUT_SKIP,
                     game: response.instance,
-                    [apk0.value()]: {
-                        id: apk0,
+                    [apk0.value()]: smartObj({
+                        meta: testMeta(apk0),
                         game: response.instance,
                         dummyCount: [
                             {
@@ -660,7 +662,7 @@ describe("Config", function() {
                                 op: PropertyOperation.ADDED
                             }
                         ]
-                    }
+                    })
                 });
                 expect(responseInstance.events.history).to.deep.equal([
                     {

--- a/test/unit/game-api.test.ts
+++ b/test/unit/game-api.test.ts
@@ -19,7 +19,9 @@ import {
     Dummy,
     aPKs,
     getInitialOutputPK,
-    oPKs
+    oPKs,
+    smartObjectEquals,
+    testMeta
 } from "../test-utils";
 import { Agent, StaticAgentRegistry } from "../../src/agents";
 import {
@@ -735,8 +737,8 @@ describe("Game API", function() {
             const pk2 = getGameInstancePK().plus(2);
 
             const r1 = Game.postStartCommand();
-            expect(r1.instance.state.parent.child).to.deep.equal({
-                id: pk2,
+            smartObjectEquals(r1.instance.state.parent.child, {
+                meta: testMeta(pk2),
                 name: "D2",
                 health: 15
             });
@@ -745,8 +747,8 @@ describe("Game API", function() {
             expect(r2.instance.state.parent).to.be.undefined;
 
             const r3 = Game.postUndoCommand(r2.instance);
-            expect(r3.instance.state.parent.child).to.deep.equal({
-                id: pk2,
+            smartObjectEquals(r3.instance.state.parent.child, {
+                meta: testMeta(pk2),
                 name: "D2",
                 health: 15
             });


### PR DESCRIPTION
## Description
* Replaces `Agent.id` with `Agent.meta` using new `AgentMeta` interface and replaces all references to `Agent.id`
* Adds `meta` property to `AgentManager`

## Checklist
### Change Type
- [ ] Bug Fix
- [ ] New Feature
- [x] Refactor (changes code but not behavior)
- [ ] Non-code Change (documentation, dependencies, etc.)

#### Is this a breaking change?
- [ ] No 
- [x] Yes

*If yes, describe what exactly this change breaks:*

Replaces `Agent.id` with `Agent.meta`

### Unit Tests
- [x] Tests Added
- [x] Tests Modified
- [ ] No Change

### Documentation
- [x] In-code Docs
- [ ] API Reference
- [ ] Other (*Specify:* )
- [ ] No Change

### Related Issues
Issue Number | Action | Notes
--- | --- | ---
#104 | Partially implemented |

### Further Action
Description | Issue Number
--- | ---
Update API reference | #105