### PR TITLE
feat(agents): Block setting arrow functions as Agent properties

### DIFF
--- a/src/agents/impl/instance-agents-impl.ts
+++ b/src/agents/impl/instance-agents-impl.ts
@@ -218,6 +218,10 @@ class InstanceAgentsImpl implements InstanceAgentsInternal {
             );
             value = this.game.using(value);
             value = new AgentArrayReference(value.meta.id);
+        } else if (typeof value === "function") {
+            throw new RegalError(
+                "Agents can't have arrow functions as properties. If you need a class method, please use traditional function syntax."
+            );
         }
 
         am.setProperty(property, value);

--- a/test/unit/agents.test.ts
+++ b/test/unit/agents.test.ts
@@ -2003,6 +2003,16 @@ describe("Agents", function() {
 
                 expect(() => myGame.using(_d)).to.throw(RegalError);
             });
+
+            it("Throws a RegalError if an agent's property is set to an arrow function", function() {
+                Game.init(MD);
+                const myGame = buildGameInstance();
+                const dummy = myGame.using(new Dummy("D1", 1));
+
+                expect(() => ((dummy as any).foo = () => "yo")).to.throw(
+                    RegalError
+                );
+            });
         });
     });
 


### PR DESCRIPTION
## Description
* `InstanceAgentsInternal` will now throw a `RegalError` if an agent's property is set to an arrow function, encouraging the developer to use a traditional function instead.

## Checklist
### Change Type
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor (changes code but not behavior)
- [ ] Non-code Change (documentation, dependencies, etc.)

#### Is this a breaking change?
- [x] No 
- [ ] Yes

*If yes, describe what exactly this change breaks:*

### Unit Tests
- [x] Tests Added
- [ ] Tests Modified
- [ ] No Change

### Documentation
- [ ] In-code Docs
- [ ] API Reference
- [ ] Other (*Specify:* )
- [ ] No Change

### Related Issues
Issue Number | Action | Notes
--- | --- | ---
#104  | Resolved |
