### PR TITLE
fix(events): Allow `on` to take a TrackedEvent or EventQueue as argum…

### DIFF
--- a/src/events/event-types.ts
+++ b/src/events/event-types.ts
@@ -41,8 +41,7 @@ export interface TrackedEvent<StateType = any>
     /** The name of the event. */
     eventName: string;
 
-    /** The `EventFunction` that is wrapped by the `TrackedEvent`. */
-    target: EventFunction<StateType>;
+    isTrackedEvent: boolean;
 
     /**
      * Adds events to the front of the event queue.
@@ -91,7 +90,7 @@ export interface EventQueue<StateType = any> extends TrackedEvent<StateType> {
 
 /** Ensures the object is a `TrackedEvent`. */
 export const isTrackedEvent = (o: any): o is TrackedEvent =>
-    o !== undefined && (o as TrackedEvent).target !== undefined;
+    o !== undefined && (o as TrackedEvent).isTrackedEvent === true;
 
 /** Ensures the object is an `EventQueue`. */
 export const isEventQueue = (o: any): o is EventQueue =>
@@ -109,9 +108,8 @@ export const noop: TrackedEvent = (() => {
     const nonEvent = (game: GameInstance) => undefined;
 
     const event = nonEvent as TrackedEvent;
-
+    event.isTrackedEvent = true;
     event.eventName = "noop";
-    event.target = nonEvent;
 
     return event;
 })();

--- a/src/events/event-types.ts
+++ b/src/events/event-types.ts
@@ -41,8 +41,8 @@ export interface TrackedEvent<StateType = any>
     /** The name of the event. */
     eventName: string;
 
-    /** Flag to designate the `TrackedEvent`. */
-    isTrackedEvent: boolean;
+    /** The `EventFunction` that is wrapped by the `TrackedEvent`. */
+    target: EventFunction<StateType>;
 
     /**
      * Adds events to the front of the event queue.
@@ -91,7 +91,7 @@ export interface EventQueue<StateType = any> extends TrackedEvent<StateType> {
 
 /** Ensures the object is a `TrackedEvent`. */
 export const isTrackedEvent = (o: any): o is TrackedEvent =>
-    o !== undefined && (o as TrackedEvent).isTrackedEvent === true;
+    o !== undefined && (o as TrackedEvent).target !== undefined;
 
 /** Ensures the object is an `EventQueue`. */
 export const isEventQueue = (o: any): o is EventQueue =>
@@ -109,8 +109,9 @@ export const noop: TrackedEvent = (() => {
     const nonEvent = (game: GameInstance) => undefined;
 
     const event = nonEvent as TrackedEvent;
-    event.isTrackedEvent = true;
+
     event.eventName = "noop";
+    event.target = nonEvent;
 
     return event;
 })();

--- a/src/events/event-types.ts
+++ b/src/events/event-types.ts
@@ -41,6 +41,7 @@ export interface TrackedEvent<StateType = any>
     /** The name of the event. */
     eventName: string;
 
+    /** Flag to designate the `TrackedEvent`. */
     isTrackedEvent: boolean;
 
     /**

--- a/src/events/impl/event-builders.ts
+++ b/src/events/impl/event-builders.ts
@@ -10,6 +10,7 @@ import {
     EventFunction,
     EventQueue,
     isEventQueue,
+    isTrackedEvent,
     TrackedEvent
 } from "../event-types";
 import { buildEventQueue, buildThenMethod } from "./event-queue-impl";
@@ -75,11 +76,20 @@ export const on = <StateType = any>(
 ): TrackedEvent<StateType> => {
     // Make the TrackedEvent callable like a function.
     const event = ((game: GameInstance) => {
-        game.events.invoke(event);
+        if (isEventQueue(eventFunc)) {
+            game.events.invoke(eventFunc);
+        } else {
+            game.events.invoke(event);
+        }
     }) as TrackedEvent;
 
     event.eventName = eventName;
-    event.target = eventFunc;
+
+    if (isTrackedEvent(eventFunc)) {
+        event.target = eventFunc.target;
+    } else {
+        event.target = eventFunc;
+    }
 
     event.then = buildThenMethod(event);
     event.thenq = (...events: TrackedEvent[]) => event.then(enqueue(...events));

--- a/src/events/impl/event-builders.ts
+++ b/src/events/impl/event-builders.ts
@@ -86,7 +86,7 @@ export const on = <StateType = any>(
     event.eventName = eventName;
 
     if (isTrackedEvent(eventFunc)) {
-        event.target = eventFunc.target;
+        event.target = () => eventFunc; // Boy oh boy this line gave me grief
     } else {
         event.target = eventFunc;
     }

--- a/test/unit/agents.test.ts
+++ b/test/unit/agents.test.ts
@@ -27,7 +27,8 @@ import {
     DEFAULT_EVENT_NAME,
     getUntrackedEventPK,
     TrackedEvent,
-    EventFunction
+    EventFunction,
+    isEventQueue
 } from "../../src/events";
 import { on } from "../../src/events";
 import { buildGameInstance } from "../../src/state";
@@ -2054,7 +2055,7 @@ describe("Agents", function() {
                 ]);
             });
 
-            it("Complicated nesting of TrackedEvents is okay", function() {
+            it("Setting complex tracked events as agent properties is okay", function() {
                 Game.init(MD);
                 const func = on("1", on("2", () => {}).then(on("3", () => {})));
                 const myGame = buildGameInstance();

--- a/test/unit/agents.test.ts
+++ b/test/unit/agents.test.ts
@@ -14,7 +14,7 @@ import {
     smartObj,
     aprPKs
 } from "../test-utils";
-import { Game } from "../../src/api";
+import { Game, onStartCommand } from "../../src/api";
 import {
     Agent,
     PropertyOperation,
@@ -23,7 +23,12 @@ import {
     StaticPrototypeRegistry
 } from "../../src/agents";
 import { RegalError } from "../../src/error";
-import { DEFAULT_EVENT_NAME, getUntrackedEventPK } from "../../src/events";
+import {
+    DEFAULT_EVENT_NAME,
+    getUntrackedEventPK,
+    TrackedEvent,
+    EventFunction
+} from "../../src/events";
 import { on } from "../../src/events";
 import { buildGameInstance } from "../../src/state";
 import {
@@ -2016,6 +2021,44 @@ describe("Agents", function() {
                 const dummy = myGame.using(new ArrowFuncAgent(() => "yo"));
 
                 expect(dummy.func()).to.equal("yo");
+            });
+
+            class TrackedEventAgent extends Agent {
+                public fn: TrackedEvent;
+                constructor(_fn: EventFunction) {
+                    super();
+                    this.fn = on("AGENT METHOD", _fn);
+                }
+            }
+
+            it("Agent properties can be tracked events with event queues as their second argument", function() {
+                Game.init(MD);
+
+                const first = on("first", game => {
+                    game.output.write("first");
+                });
+
+                const second = on("second", game => {
+                    game.output.write("second");
+                });
+
+                const myGame = buildGameInstance();
+                const agent = myGame.using(
+                    new TrackedEventAgent(first.then(second))
+                );
+
+                agent.fn(myGame);
+                expect(myGame.output.lines.map(l => l.data)).to.deep.equal([
+                    "first",
+                    "second"
+                ]);
+            });
+
+            it("Complicated nesting of TrackedEvents is okay", function() {
+                Game.init(MD);
+                const func = on("1", on("2", () => {}).then(on("3", () => {})));
+                const myGame = buildGameInstance();
+                myGame.using(new TrackedEventAgent(func)).fn(myGame);
             });
         });
     });

--- a/test/unit/events.test.ts
+++ b/test/unit/events.test.ts
@@ -477,6 +477,12 @@ describe("Events", function() {
             ]);
         });
 
+        it("TrackedEvent.then returns an EventQueue", function() {
+            Game.init(MD);
+            const eq = on("FOO", on("BAZ", () => {})).then(on("BAR", () => {}));
+            expect(isEventQueue(eq)).to.be.true;
+        });
+
         describe("QTests", function() {
             // Start utility functions
 


### PR DESCRIPTION
## Description
* Allows `on` to take a `TrackedEvent` or `EventQueue` as an argument

## Checklist
### Change Type
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor (changes code but not behavior)
- [ ] Non-code Change (documentation, dependencies, etc.)

#### Is this a breaking change?
- [x] No 
- [ ] Yes

*If yes, describe what exactly this change breaks:*

### Unit Tests
- [x] Tests Added
- [ ] Tests Modified
- [ ] No Change

### Documentation
- [x] In-code Docs
- [ ] API Reference
- [ ] Other (*Specify:* )
- [ ] No Change

### Related Issues
Issue Number | Action | Notes
--- | --- | ---
#83  | Resolved |
