### PR TITLE
Remove error if Agent property is arrow function

### DIFF
--- a/src/agents/impl/instance-agents-impl.ts
+++ b/src/agents/impl/instance-agents-impl.ts
@@ -218,10 +218,6 @@ class InstanceAgentsImpl implements InstanceAgentsInternal {
             );
             value = this.game.using(value);
             value = new AgentArrayReference(value.meta.id);
-        } else if (typeof value === "function") {
-            throw new RegalError(
-                "Agents can't have arrow functions as properties. If you need a class method, please use traditional function syntax."
-            );
         }
 
         am.setProperty(property, value);

--- a/test/unit/agents.test.ts
+++ b/test/unit/agents.test.ts
@@ -2004,14 +2004,18 @@ describe("Agents", function() {
                 expect(() => myGame.using(_d)).to.throw(RegalError);
             });
 
-            it("Throws a RegalError if an agent's property is set to an arrow function", function() {
+            class ArrowFuncAgent extends Agent {
+                constructor(public func: () => {}) {
+                    super();
+                }
+            }
+
+            it("Agent properties can be arrow functions", function() {
                 Game.init(MD);
                 const myGame = buildGameInstance();
-                const dummy = myGame.using(new Dummy("D1", 1));
+                const dummy = myGame.using(new ArrowFuncAgent(() => "yo"));
 
-                expect(() => ((dummy as any).foo = () => "yo")).to.throw(
-                    RegalError
-                );
+                expect(dummy.func()).to.equal("yo");
             });
         });
     });


### PR DESCRIPTION
## Description
* Removes error that is thrown if Agent property is an arrow function

## Checklist
### Change Type
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor (changes code but not behavior)
- [ ] Non-code Change (documentation, dependencies, etc.)

#### Is this a breaking change?
- [x] No 
- [ ] Yes

*If yes, describe what exactly this change breaks:*

### Unit Tests
- [x] Tests Added
- [x] Tests Modified
- [ ] No Change

### Documentation
- [ ] In-code Docs
- [ ] API Reference
- [ ] Other (*Specify:* )
- [x] No Change

### Related Issues
Issue Number | Action | Notes
--- | --- | ---
#119  | Resolved |